### PR TITLE
Boilerplate mail list should be public-webappsec

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
                       href: 'https://github.com/w3c/permissions/commits/gh-pages'
                   }, {
                       value: 'Mailing list.',
-                      href: 'http://lists.w3.org/Archives/Public/public-webapps/'
+                      href: 'http://lists.w3.org/Archives/Public/public-webappsec/'
                   }]
         },{
             key: 'Implementation status',


### PR DESCRIPTION
The Mailing List in the boilerplate says p-webapps and since WebAppSec is now publishing this spec, the list should now say p-webappsec.