### PR TITLE
Make Permissions.request() only take a single descriptor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,12 +99,22 @@
       </p>
       <ul>
         <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">
+          browsing context</a></dfn>
+        </li>
+        <li>
           <a href=
           'https://html.spec.whatwg.org/multipage/browsers.html#origin-2'><dfn>origin</dfn></a>
           of a <a href=
           'https://html.spec.whatwg.org/multipage/dom.html#document'><dfn>Document</dfn></a>
           and a <a href=
           'https://html.spec.whatwg.org/multipage/workers.html#workers'><dfn>worker</dfn></a>.
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">
+          environment settings object</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -134,6 +144,16 @@
           <dfn><a href=
           'https://html.spec.whatwg.org/multipage/webappapis.html#global-object'>
           global object</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">
+          parent browsing context</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">
+          top-level browsing context</a></dfn>
         </li>
       </ul>
       <p>
@@ -376,14 +396,30 @@
         Permission Store
       </h2>
       <p>
-        <a title='user agent'>User agents</a> MAY use a form of storage to keep
-        track of web site permissions. When they do, they MUST have a <dfn>
-        permission storage identifier</dfn> which is linked to a <dfn>permission
-        storage entry</dfn>. The <a>permission storage identifier</a> MUST
-        contain the website's origin and MAY contain other information like the
-        embedding status or the embedder's origin. The <a>permission storage
+        <a lt='user agent'>User agents</a> MAY use a form of storage to keep
+        track of web site permissions. When they do, they MUST have a
+        <dfn>permission storage identifier</dfn> which is linked to a
+        <dfn>permission storage entry</dfn>. The <a>permission storage
         entry</a> MUST be a <a>PermissionState</a> or <code>undefined</code>.
       </p>
+      <p>
+        To <dfn>get a permission storage identifier</dfn> for a
+        <a>PermissionName</a> <var>name</var> and an <a>environment settings
+        object</a> <var>settings</var>, the UA MUST return a tuple consisting
+        of:
+      </p>
+      <ol>
+        <li>
+          <var>name</var>
+        </li>
+        <li>
+          <var>settings</var>' <a>origin</a>
+        </li>
+        <li>optional UA-specific data like whether <var>settings</var>'
+        <a>browsing context</a> has a <a>parent browsing context</a>, or <var>
+          settings</var>' <a>top-level browsing context</a>'s <a>origin</a>
+        </li>
+      </ol>
       <p>
         The steps to <dfn>retrieve a permission storage entry</dfn> of a
         <a>permission storage identifier</a> are as follows:
@@ -452,9 +488,15 @@
         follows:
       </p>
       <ol>
-        <li>Let <var>identifier</var> be the <a>permission storage identifier</a>
-        associated with the <a>origin</a>, <a>global object</a> and <code>permission</code>.</li>
-        <li>Run the steps to <a>retrieve a permission storage entry</a>.</li>
+        <li>
+          <a>Get a permission storage identifier</a> for
+          <var>permission</var>'s <a>PermissionName</a> and the current
+          <a>environment settings object</a>, and let <var>identifier</var> be
+          the result.
+        </li>
+        <li>Run the steps to <a>retrieve a permission storage entry</a> of
+        <var>identifier</var>.
+        </li>
         <li>If the result of those steps are not <code>undefined</code>, return
         it and abort these steps.</li>
         <li>Otherwise, the <a>user agent</a> MUST return a default value based
@@ -638,8 +680,11 @@
         </li>
         <li>Return <var>promise</var> and continue the following steps asynchronously.
         </li>
-        <li>Let <var>identifier</var> be the <a>permission storage identifier</a>
-        associated with the <a>origin</a>, <a>global object</a> and <var>permission</var>.
+        <li>
+          <a>Get a permission storage identifier</a> for
+          <code><var>permission</var>.name</code> and the current
+          <a>environment settings object</a>, and let <var>identifier</var> be
+          the result.
         </li>
         <li>Run the steps to <a>delete a permission storage entry</a> using
         <var>identifier</var>.</li>

--- a/index.html
+++ b/index.html
@@ -605,7 +605,7 @@
         interface Permissions {
           Promise&lt;PermissionStatus&gt; query(PermissionDescriptor permission);
 
-          Promise&lt;PermissionStatus&gt; request((PermissionDescriptor or sequence&lt;PermissionDescriptor&gt;) permissions);
+          Promise&lt;PermissionStatus&gt; request(PermissionDescriptor permission);
 
           Promise&lt;PermissionStatus&gt; revoke(PermissionDescriptor permission);
         };

--- a/index.html
+++ b/index.html
@@ -569,8 +569,10 @@
         };
       </pre>
       <p>
-        When the <dfn for='Permissions' title='query'><code>query()</code></dfn>
-        method is invoked, the <a>user agent</a> MUST run the following steps:
+        When the <dfn for='Permissions' lt='query'><code>query()</code></dfn>
+        method is invoked, the <a>user agent</a> MUST run the following
+        <dfn data-export="">query a permission</dfn> algorithm, passing the
+        parameter <var>permission</var>:
       </p>
       <ol>
         <li>If <var>permission.name</var> has an <a>associated
@@ -602,15 +604,20 @@
         found in the <a href='#examples'>Examples section</a>.
       </div>
       <p>
-        When the <dfn for='Permissions' title='request'><code>request()</code></dfn>
-        method is invoked, the <a>user agent</a> MUST run the following steps:
+        When the <dfn for='Permissions' lt=
+        'request'><code>request()</code></dfn> method is invoked, the <a>user
+        agent</a> MUST run the following <dfn data-export="">request a
+        permission</dfn> algorithm, passing the parameter
+        <var>permission</var>:
       </p>
       <ol>
         <li>TODO</li>
       </ol>
       <p>
-        When the <dfn for='Permissions' title='revoke'><code>revoke()</code></dfn>
-        method is invoked, the <a>user agent</a> MUST run the following steps:
+        When the <dfn for='Permissions' lt='revoke'><code>revoke()</code></dfn>
+        method is invoked, the <a>user agent</a> MUST run the following
+        <dfn data-export="">revoke a permission</dfn> algorithm, passing the
+        parameter <var>permission</var>:
       </p>
       <ol>
         <li>If <var>permission.name</var> has an <a>associated


### PR DESCRIPTION
This matches the [current Chromium implementation](https://code.google.com/p/chromium/codesearch/#chromium/src/third_party/WebKit/Source/modules/permissions/Permissions.idl), which has a `requestAll()` function to handle a sequence of permissions. A sequence could also be handled with `Promise.all()`, like [`query()` suggests](https://rawgit.com/jyasskin/permissions/no-request-sequence/index.html#h-note1).