### PR TITLE
Remove the incorrect paragraph about request() and revoke() having been removed from the spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -85,13 +85,6 @@ spec: webidl
     this document, please contact the editors or file an issue. We would
     love to hear about it.
   </p>
-  <p>
-    The initial intent of this document was to allow web applications to
-    request and revoke permissions explicitly in addition to querying the
-    permission status. This is an aspect of the specification that was
-    controversial thus removed from the current document in a spirit of
-    incremental changes: settling on a small API that can be improved.
-  </p>
 </section>
 <section class='non-normative'>
   <h2 id="privacy-considerations">

--- a/index.html
+++ b/index.html
@@ -1345,7 +1345,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">The Permissions API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-11">11 April 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-14">14 April 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1467,11 +1467,6 @@ Possible extra rowspan handling
     that has a permission model that wouldn’t fit in the model described in
     this document, please contact the editors or file an issue. We would
     love to hear about it. </p>
-    <p> The initial intent of this document was to allow web applications to
-    request and revoke permissions explicitly in addition to querying the
-    permission status. This is an aspect of the specification that was
-    controversial thus removed from the current document in a spirit of
-    incremental changes: settling on a small API that can be improved. </p>
    </section>
    <section class="non-normative">
     <h2 class="heading settled" data-level="2" id="privacy-considerations"><span class="secno">2. </span><span class="content"> Privacy considerations </span><a class="self-link" href="#privacy-considerations"></a></h2>


### PR DESCRIPTION
This paragraph keeps confusing people, since these functions are in fact specified. Removing the paragraph doesn't guarantee we'll keep the functions: it just makes the spec self-consistent.