### PR TITLE
Export dfn-type definitions that other specs should be able to use.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -212,7 +212,7 @@ spec: webidl
     </dd>
   </dl>
   <p>
-    A <dfn>boolean permission</dfn> is a <a>permission</a> with all types
+    A <dfn export>boolean permission</dfn> is a <a>permission</a> with all types
     and algorithms defaulted.
   </p>
   <section>
@@ -374,13 +374,13 @@ spec: webidl
   </section>
 </section>
 <section>
-  <h2 dfn-type="dfn">
+  <h2 dfn-type="dfn" export>
     Permission Store
   </h2>
   <p>
     <a data-lt='user agent'>User agents</a> MAY use a form of storage to
     keep track of web site permissions. When they do, they MUST have a
-    <dfn>permission storage identifier</dfn> which is linked to a
+    <dfn export>permission storage identifier</dfn> which is linked to a
     {{PermissionStorage}} instance or one of its subtypes.
   </p>
   <p>
@@ -474,7 +474,7 @@ spec: webidl
     feature. The user might grant, deny or dismiss the request.
   </p>
   <p>
-    The steps to <dfn>retrieve the permission storage</dfn> for a given
+    The steps to <dfn export>retrieve the permission storage</dfn> for a given
     {{PermissionName}} <var>name</var> are as follows:
   </p>
   <ol>
@@ -782,7 +782,7 @@ spec: webidl
     Common permission algorithms
   </h2>
   <p>
-    The <dfn>boolean permission query algorithm</dfn>, given a
+    The <dfn export>boolean permission query algorithm</dfn>, given a
     {{PermissionDescriptor}} <var>permissionDesc</var>, a
     {{PermissionStorage}} <var>storage</var>, and a
     {{PermissionStatus}} <var>status</var>, runs the following steps:
@@ -793,7 +793,7 @@ spec: webidl
     </li>
   </ol>
   <p>
-    The <dfn>boolean permission request algorithm</dfn>, given a
+    The <dfn export>boolean permission request algorithm</dfn>, given a
     {{PermissionDescriptor}} <var>permission</var> and a
     {{PermissionStatus}} <var>status</var>, runs the following steps:
   </p>

--- a/index.html
+++ b/index.html
@@ -1345,7 +1345,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">The Permissions API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-11">11 April 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-14">14 April 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1590,7 +1590,7 @@ Possible extra rowspan handling
       permission store. Triggered by <code class="idl"><a data-link-type="idl" href="#permissions" id="ref-for-permissions-3">Permissions</a></code>' <code class="idl"><a data-link-type="idl" href="#dom-permissions-revoke" id="ref-for-dom-permissions-revoke-1">revoke()</a></code> method. If unspecified, this
       defaults to doing nothing. 
     </dl>
-    <p> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="boolean permission" data-noexport="" id="boolean-permission">boolean permission<span class="dfn-panel" data-deco=""><b><a href="#boolean-permission">#boolean-permission</a></b><b>Referenced in:</b><span><a href="#ref-for-boolean-permission-1">4.1. 
+    <p> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="boolean permission" id="boolean-permission">boolean permission<span class="dfn-panel" data-deco=""><b><a href="#boolean-permission">#boolean-permission</a></b><b>Referenced in:</b><span><a href="#ref-for-boolean-permission-1">4.1. 
       Geolocation </a></span><span><a href="#ref-for-boolean-permission-2">4.2. 
       Notifications </a></span></span></dfn> is a <a data-link-type="dfn" href="#permission" id="ref-for-permission-2">permission</a> with all types
     and algorithms defaulted. </p>
@@ -1685,10 +1685,10 @@ Possible extra rowspan handling
     </section>
    </section>
    <section>
-    <h2 class="heading settled dfn-paneled" data-dfn-type="dfn" data-level="5" data-lt="Permission Store" data-noexport="" id="permission-store"><span class="secno">5. </span><span class="content"> Permission Store </span><span class="dfn-panel" data-deco=""><b><a href="#permission-store">#permission-store</a></b><b>Referenced in:</b><span><a href="#ref-for-permission-store-1">4. 
+    <h2 class="heading settled dfn-paneled" data-dfn-type="dfn" data-export="" data-level="5" data-lt="Permission Store" id="permission-store"><span class="secno">5. </span><span class="content"> Permission Store </span><span class="dfn-panel" data-deco=""><b><a href="#permission-store">#permission-store</a></b><b>Referenced in:</b><span><a href="#ref-for-permission-store-1">4. 
     Permission Registry </a></span></span></h2>
     <p> <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#dfn-user-agent">User agents</a> MAY use a form of storage to
-    keep track of web site permissions. When they do, they MUST have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="permission storage identifier" data-noexport="" id="permission-storage-identifier">permission storage identifier<span class="dfn-panel" data-deco=""><b><a href="#permission-storage-identifier">#permission-storage-identifier</a></b><b>Referenced in:</b><span><a href="#ref-for-permission-storage-identifier-1">5. 
+    keep track of web site permissions. When they do, they MUST have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="permission storage identifier" id="permission-storage-identifier">permission storage identifier<span class="dfn-panel" data-deco=""><b><a href="#permission-storage-identifier">#permission-storage-identifier</a></b><b>Referenced in:</b><span><a href="#ref-for-permission-storage-identifier-1">5. 
     Permission Store </a> <a href="#ref-for-permission-storage-identifier-2">(2)</a> <a href="#ref-for-permission-storage-identifier-3">(3)</a> <a href="#ref-for-permission-storage-identifier-4">(4)</a> <a href="#ref-for-permission-storage-identifier-5">(5)</a> <a href="#ref-for-permission-storage-identifier-6">(6)</a></span></span></dfn> which is linked to a <code class="idl"><a data-link-type="idl" href="#dictdef-permissionstorage" id="ref-for-dictdef-permissionstorage-3">PermissionStorage</a></code> instance or one of its subtypes. </p>
     <p> To <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="get a permission storage identifier" data-noexport="" id="get-a-permission-storage-identifier">get a permission storage identifier<span class="dfn-panel" data-deco=""><b><a href="#get-a-permission-storage-identifier">#get-a-permission-storage-identifier</a></b><b>Referenced in:</b><span><a href="#ref-for-get-a-permission-storage-identifier-1">6. 
     Status of a permission </a></span><span><a href="#ref-for-get-a-permission-storage-identifier-2">8. 
@@ -1765,7 +1765,7 @@ Possible extra rowspan handling
     Status of a permission </a> <a href="#ref-for-dom-permissionstate-prompt-3">(2)</a></span></span></dfn> state represents
     that the <a data-link-type="dfn" href="https://www.w3.org/TR/uievents/#dfn-user-agent">user agent</a> will be asking the user’s permission if the caller tries to access the
     feature. The user might grant, deny or dismiss the request. </p>
-    <p> The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="retrieve the permission storage" data-noexport="" id="retrieve-the-permission-storage">retrieve the permission storage<span class="dfn-panel" data-deco=""><b><a href="#retrieve-the-permission-storage">#retrieve-the-permission-storage</a></b><b>Referenced in:</b><span><a href="#ref-for-retrieve-the-permission-storage-1">6. 
+    <p> The steps to <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="retrieve the permission storage" id="retrieve-the-permission-storage">retrieve the permission storage<span class="dfn-panel" data-deco=""><b><a href="#retrieve-the-permission-storage">#retrieve-the-permission-storage</a></b><b>Referenced in:</b><span><a href="#ref-for-retrieve-the-permission-storage-1">6. 
     Status of a permission </a></span><span><a href="#ref-for-retrieve-the-permission-storage-2">8. 
     Permissions interface </a></span></span></dfn> for a given <code class="idl"><a data-link-type="idl" href="#enumdef-permissionname" id="ref-for-enumdef-permissionname-4">PermissionName</a></code> <var>name</var> are as follows: </p>
     <ol>
@@ -1960,12 +1960,12 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
    </section>
    <section>
     <h2 class="heading settled" data-level="9" id="common-permission-algorithms"><span class="secno">9. </span><span class="content"> Common permission algorithms </span><a class="self-link" href="#common-permission-algorithms"></a></h2>
-    <p> The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="boolean permission query algorithm" data-noexport="" id="boolean-permission-query-algorithm">boolean permission query algorithm<span class="dfn-panel" data-deco=""><b><a href="#boolean-permission-query-algorithm">#boolean-permission-query-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-boolean-permission-query-algorithm-1">4. 
+    <p> The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="boolean permission query algorithm" id="boolean-permission-query-algorithm">boolean permission query algorithm<span class="dfn-panel" data-deco=""><b><a href="#boolean-permission-query-algorithm">#boolean-permission-query-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-boolean-permission-query-algorithm-1">4. 
     Permission Registry </a></span></span></dfn>, given a <code class="idl"><a data-link-type="idl" href="#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor-12">PermissionDescriptor</a></code> <var>permissionDesc</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-permissionstorage" id="ref-for-dictdef-permissionstorage-10">PermissionStorage</a></code> <var>storage</var>, and a <code class="idl"><a data-link-type="idl" href="#permissionstatus" id="ref-for-permissionstatus-9">PermissionStatus</a></code> <var>status</var>, runs the following steps: </p>
     <ol class="algorithm">
      <li>Set <code><var>status</var>.state</code> to <code><var>storage</var>.state</code> 
     </ol>
-    <p> The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="boolean permission request algorithm" data-noexport="" id="boolean-permission-request-algorithm">boolean permission request algorithm<span class="dfn-panel" data-deco=""><b><a href="#boolean-permission-request-algorithm">#boolean-permission-request-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-boolean-permission-request-algorithm-1">4. 
+    <p> The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="boolean permission request algorithm" id="boolean-permission-request-algorithm">boolean permission request algorithm<span class="dfn-panel" data-deco=""><b><a href="#boolean-permission-request-algorithm">#boolean-permission-request-algorithm</a></b><b>Referenced in:</b><span><a href="#ref-for-boolean-permission-request-algorithm-1">4. 
     Permission Registry </a></span></span></dfn>, given a <code class="idl"><a data-link-type="idl" href="#dictdef-permissiondescriptor" id="ref-for-dictdef-permissiondescriptor-13">PermissionDescriptor</a></code> <var>permission</var> and a <code class="idl"><a data-link-type="idl" href="#permissionstatus" id="ref-for-permissionstatus-10">PermissionStatus</a></code> <var>status</var>, runs the following steps: </p>
     <ol class="algorithm">
      <li>TODO 


### PR DESCRIPTION
* permission store
* permission storage identifier
* retrieve the permission storage
* boolean permission
* boolean permission query algorithm
* boolean permission request algorithm

Web Bluetooth is about to use the first 3 of these. It also uses a couple other terms, but I think it's a bug that it needs to, so I don't want to export them.