### PR TITLE
Retitle the Permissions spec to emphasize the infrastructure more.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: The Permissions API
+Title: Permissions
 Repository: w3c/permissions
 Status: ED
 ED: https://w3c.github.io/permissions/
@@ -10,7 +10,7 @@ Editor: Mounir Lamouri, Google Inc. https://google.com/
 Editor: Marcos Cáceres, Mozilla https://mozilla.com/
 Editor: Jeffrey Yasskin, Google Inc. https://google.com/
 
-Abstract: The <cite>Permissions API</cite> allows a web application to be aware of the status of a given permission, to know whether it is granted, denied or if the user will be asked whether the permission should be granted.
+Abstract: The <cite>Permissions Standard</cite> defines common infrastructure for other specifications that need to interact with browser permissions. It also defines an API to allow web applications to query and request changes to the status of a given permission.
 Mailing List: public-webappsec@w3.org
 Mailing List Archives: http://lists.w3.org/Archives/Public/public-webappsec/
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <title>The Permissions API</title>
+  <title>Permissions</title>
 <style data-fill-with="stylesheet">/******************************************************************************
  *                   Style sheet for the W3C specifications                   *
  *
@@ -1344,8 +1344,8 @@ Possible extra rowspan handling
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
-   <h1 class="p-name no-ref" id="title">The Permissions API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-17">17 April 2016</time></span></h2>
+   <h1 class="p-name no-ref" id="title">Permissions</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-04-21">21 April 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1375,7 +1375,7 @@ Possible extra rowspan handling
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
-   <p>The <cite>Permissions API</cite> allows a web application to be aware of the status of a given permission, to know whether it is granted, denied or if the user will be asked whether the permission should be granted.</p>
+   <p>The <cite>Permissions Standard</cite> defines common infrastructure for other specifications that need to interact with browser permissions. It also defines an API to allow web applications to query and request changes to the status of a given permission.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">


### PR DESCRIPTION
Like https://storage.spec.whatwg.org/, this spec defines both an API and
common terminology and infrastructure that can underpin other
specifications.

Preview at https://rawgit.com/jyasskin/permissions/retitle/index.html.

I'll also rearrange some of the sections to more clearly separate the API from the infrastructure, but I'd like to be sure the renaming has general agreement first, so I don't need to maintain a reordering in a long-lived branch.