### PR TITLE
Allow UAs to maintain zero or multiple permission stores.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -49,6 +49,7 @@ spec: html
         text: parent browsing context
         text: queue a task
         text: same origin
+        text: the environment settings object's realm
         text: top-level browsing context
 spec: ui-events
     type: dfn
@@ -377,18 +378,22 @@ spec: webidl
     Permission Stores
   </h2>
   <p>
-    A <dfn export>permission store</dfn> maps {{PermissionName}}s to instances
-    of {{PermissionStorage}} or one of its subtypes. A <a>permission store</a>
-    has one or more associated <a>origin</a>s, and SHOULD have only one.
+    A <dfn export lt="permission store|permission stores">permission
+    store</dfn> maps {{PermissionName}}s to instances of
+    {{PermissionStorage}} or one of its subtypes. A <a>permission
+    store</a> has one or more associated <a>origin</a>s, and SHOULD
+    have only one.
   </p>
   <p>
-    The <a>user agent</a> MAY maintain any number of <a>permission store</a>s to
+    The <a>user agent</a> MAY maintain any number of <a>permission stores</a> to
     record what capabilities users have granted web sites permission to access.
-    The <a>user agent</a> may create new <a>permission store</a>s, for example
-    to serve a particular <a>origin</a>, <a>origin</a> within a <a>top-level
-    browsing context</a>, or <a>realm</a>, and when it does so, it may
-    initialize it using the mappings of any other <a>permission store</a>
-    associated with the <a>same origin</a>.
+    If the UA maintains any <a>permission stores</a>, the UA MUST create a new
+    <a>permission store</a> for each <a>realm</a> and may create new
+    <a>permission stores</a> for other reasons, for example to serve a
+    particular <a>origin</a> or <a>origin</a> within a <a>top-level browsing
+    context</a>. The UA may initialize new <a>permission stores</a> as empty or
+    as a copy of the mappings of any other <a>permission store</a> associated
+    with the <a>same origin</a>.
   </p>
 
   <pre class='idl'>
@@ -406,9 +411,9 @@ spec: webidl
   <ol>
     <li>Let <var>settings</var> be the <a>current settings object</a>.</li>
     <li>
-      Let <var>store</var> be some <a>permission store</a> associated with the
-      <a>same origin</a> as <var>settings</var>. This store SHOULD be chosen
-      consistently for a given <a>environment settings object</a>.
+      Let <var>store</var> be the <a>permission store</a> associated with
+      <var>settings</var>' <a lt="the environment settings object's
+      Realm">realm</a>.
     </li>
     <li>
       If <var>store</var> exists and maps <var>name</var> to a value, return
@@ -430,9 +435,9 @@ spec: webidl
     <li>
       Let <var>stores</var> be a collection of zero or more <a>permission
       store</a>s associated with the <a>same origin</a> as <var>settings</var>.
-      If <var>stores</var> is non-empty, it SHOULD include the permission store
-      used in the <a>retrieve the permission storage</a> algorithm for
-      <var>settings</var>.
+      If <var>stores</var> is non-empty, it MUST include the permission store
+      associated with <var>settings</var>' <a lt="the environment settings
+      object's Realm">realm</a>.
     </li>
     <li>
       Write a mapping from <var>name</var> to <var>storage</var> into each

--- a/index.bs
+++ b/index.bs
@@ -25,6 +25,8 @@ Markup Shorthands: css no, markdown yes
 </pre>
 <pre class="anchors">
 spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
+    type: dfn
+        text: realm; url: sec-code-realms
     type: interface
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
@@ -39,12 +41,14 @@ spec: promises-guide; urlPrefix: https://www.w3.org/2001/tag/doc/promises-guide#
 spec: html
     type: dfn
         text: browsing context
+        text: current settings object
         text: environment settings object
         text: event handler
         text: event handler event type
         text: origin
         text: parent browsing context
         text: queue a task
+        text: same origin
         text: top-level browsing context
 spec: ui-events
     type: dfn
@@ -369,33 +373,24 @@ spec: webidl
   </section>
 </section>
 <section>
-  <h2 dfn-type="dfn" export>
-    Permission Store
+  <h2 id="permission-stores">
+    Permission Stores
   </h2>
   <p>
-    <a lt='user agent'>User agents</a> MAY use a form of storage to
-    keep track of web site permissions. When they do, they MUST have a
-    <dfn export>permission storage identifier</dfn> which is linked to a
-    {{PermissionStorage}} instance or one of its subtypes.
+    A <dfn export>permission store</dfn> maps {{PermissionName}}s to instances
+    of {{PermissionStorage}} or one of its subtypes. A <a>permission store</a>
+    has one or more associated <a>origin</a>s, and SHOULD have only one.
   </p>
   <p>
-    To <dfn>get a permission storage identifier</dfn> for a
-    {{PermissionName}} <var>name</var> and an <a>environment settings
-    object</a> <var>settings</var>, the UA MUST return a tuple consisting
-    of:
+    The <a>user agent</a> MAY maintain any number of <a>permission store</a>s to
+    record what capabilities users have granted web sites permission to access.
+    The <a>user agent</a> may create new <a>permission store</a>s, for example
+    to serve a particular <a>origin</a>, <a>origin</a> within a <a>top-level
+    browsing context</a>, or <a>realm</a>, and when it does so, it may
+    initialize it using the mappings of any other <a>permission store</a>
+    associated with the <a>same origin</a>.
   </p>
-  <ol>
-    <li>
-      <var>name</var>
-    </li>
-    <li>
-      <var>settings</var>' <a>origin</a>
-    </li>
-    <li>optional UA-specific data like whether <var>settings</var>'
-    <a>browsing context</a> has a <a>parent browsing context</a>, or
-    <var>settings</var>' <a>top-level browsing context</a>'s <a>origin</a>
-    </li>
-  </ol>
+
   <pre class='idl'>
     dictionary PermissionStorage {
       // PermissionStorage is just an explanatory device.
@@ -405,38 +400,66 @@ spec: webidl
     };
   </pre>
   <p>
-    The steps to <dfn>retrieve a permission storage entry</dfn> of a
-    <a>permission storage identifier</a> are as follows:
+    The steps to <dfn export>retrieve the permission storage</dfn> of a
+    {{PermissionName}} <var>name</var> are as follows:
   </p>
   <ol>
-    <li>If the <a>user agent</a> has a {{PermissionStorage}} associated
-    with the <a>permission storage identifier</a> in its permission store,
-    it MUST return the {{PermissionStorage}}.
+    <li>Let <var>settings</var> be the <a>current settings object</a>.</li>
+    <li>
+      Let <var>store</var> be some <a>permission store</a> associated with the
+      <a>same origin</a> as <var>settings</var>. This store SHOULD be chosen
+      consistently for a given <a>environment settings object</a>.
     </li>
-    <li>Otherwise, it MUST return <code>undefined</code>.
+    <li>
+      If <var>store</var> exists and maps <var>name</var> to a value, return
+      this value.
+    </li>
+    <li>
+      Otherwise, return a default value based on the <a>user agent</a>'s defined
+      heuristics. For example, <code>{state: {{"prompt"}}}</code> can be a
+      default value, but it can also be based on frequency of visits.
     </li>
   </ol>
   <p>
-    The steps to <dfn>create a permission storage entry</dfn> for a
-    <a>permission storage identifier</a> are as follows:
+    The steps to <dfn>create a permission storage entry</dfn> mapping a
+    {{PermissionName}} <var>name</var> to a {{PermissionStorage}}
+    <var>storage</var> are as follows:
   </p>
   <ol>
-    <li>If the <a>user agent</a> has a {{PermissionStorage}} associated
-    with the <a>permission storage identifier</a> in its permission store,
-    it MUST overwrite it to the given {{PermissionStorage}}.
+    <li>Let <var>settings</var> be the <a>current settings object</a>.</li>
+    <li>
+      Let <var>stores</var> be a collection of zero or more <a>permission
+      store</a>s associated with the <a>same origin</a> as <var>settings</var>.
+      If <var>stores</var> is non-empty, it SHOULD include the permission store
+      used in the <a>retrieve the permission storage</a> algorithm for
+      <var>settings</var>.
     </li>
-    <li>Otherwise, it MUST write the new {{PermissionStorage}} to its
-    permission store.
+    <li>
+      Write a mapping from <var>name</var> to <var>storage</var> into each
+      <a>permission store</a> in <var>stores</var>, overwriting any existing
+      mapping with the same <var>name</var>.
+
+      Issue(91): This isn't quite sufficient for complex {{PermissionStorage}}
+      subclasses, which may need to modify the old storage instead of just
+      overwriting it.
     </li>
   </ol>
   <p>
     The steps to <dfn>delete a permission storage entry</dfn> of a
-    <a>permission storage identifier</a> are as follows:
+    {{PermissionName}} <var>name</var> are as follows:
   </p>
   <ol>
-    <li>If the <a>user agent</a> has a {{PermissionStorage}} associated
-    with the <a>permission storage identifier</a> in its permission store,
-    it MUST remove it.
+    <li>Let <var>settings</var> be the <a>current settings object</a>.</li>
+    <li>
+      Let <var>stores</var> be a collection of zero or more <a>permission
+      store</a>s associated with the <a>same origin</a> as <var>settings</var>.
+      If <var>stores</var> is non-empty, it SHOULD include the permission store
+      used in the <a>retrieve the permission storage</a> algorithm for
+      <var>settings</var>.
+    </li>
+    <li>
+      Remove all the mappings for <var>name</var> from <a>permission store</a>s
+      in <var>stores</var>.
     </li>
   </ol>
 </section>
@@ -468,28 +491,7 @@ spec: webidl
     will be asking the user's permission if the caller tries to access the
     feature. The user might grant, deny or dismiss the request.
   </p>
-  <p>
-    The steps to <dfn export>retrieve the permission storage</dfn> for a given
-    {{PermissionName}} <var>name</var> are as follows:
-  </p>
-  <ol>
-    <li>
-      <a>Get a permission storage identifier</a> for <var>name</var> and
-      the current <a>environment settings object</a>, and let
-      <var>identifier</var> be the result.
-    </li>
-    <li>Run the steps to <a>retrieve a permission storage entry</a> of
-    <var>identifier</var>.
-    </li>
-    <li>If the result of those steps are not <code>undefined</code>, return
-    it and abort these steps.
-    </li>
-    <li>Otherwise, the <a>user agent</a> MUST return a default value based
-    on <a>user agent</a>'s defined heuristics. For example, <code>{state:
-    {{"prompt"}}}</code> can be a default value, but it can also be based on
-    frequency of visits.
-    </li>
-  </ol>
+
   <pre class='idl'>
     [Exposed=(Window,Worker)]
     interface PermissionStatus : EventTarget {
@@ -719,10 +721,8 @@ spec: webidl
     steps.
     </li>
     <li>
-      <a>Get a permission storage identifier</a> for
-      <code><var>permissionDesc</var>.name</code> and the current
-      <a>environment settings object</a>, and <a>create a permission
-      storage entry</a> mapping this identifier to <var>storage</var>.
+      <a>Create a permission storage entry</a> mapping
+      <code><var>permissionDesc</var>.name</code> to <var>storage</var>.
     </li>
     <li>Return <var>status</var>.
     </li>
@@ -754,14 +754,8 @@ spec: webidl
     <li>Return <var>promise</var> and continue the following steps
     asynchronously.
     </li>
-    <li>
-      <a>Get a permission storage identifier</a> for
-      <code><var>permission</var>.name</code> and the current
-      <a>environment settings object</a>, and let <var>identifier</var> be
-      the result.
-    </li>
-    <li>Run the steps to <a>delete a permission storage entry</a> using
-    <var>identifier</var>.
+    <li>Run the steps to <a>delete a permission storage entry</a> of
+      <code><var>permission</var>.name</code>.
     </li>
     <li>Run <code><var>permissionDesc</var>.name</code>'s <a>permission revocation
     algorithm</a>.

--- a/index.bs
+++ b/index.bs
@@ -481,8 +481,8 @@ spec: webidl
   <ol>
     <li>Let <var>settings</var> be the <a>current settings object</a>.</li>
     <li>
-      Let <var>stores</var> be a collection of zero or more <a>permission
-      store</a>s associated with the <a>same origin</a> as <var>settings</var>.
+      Let <var>stores</var> be a UA-selected subset of the <a>permission
+      stores</a> associated with the <a>same origin</a> as <var>settings</var>.
       If <var>stores</var> is non-empty, it MUST include the permission store
       associated with <var>settings</var>' <a lt="the environment settings
       object's Realm">realm</a>.

--- a/index.bs
+++ b/index.bs
@@ -382,7 +382,10 @@ spec: webidl
     store</dfn> maps {{PermissionName}}s to instances of
     {{PermissionStorage}} or one of its subtypes. A <a>permission
     store</a> has one or more associated <a>origin</a>s, and SHOULD
-    have only one.
+    have only one. <span class="note">For example, when a user grants permission
+    for https://foo.com/ to use a capability, some browsers will also give
+    access to any origin with a domain ending in ".foo.com". This is discouraged
+    but allowed.</span>
   </p>
   <p>
     The <a>user agent</a> MAY maintain any number of <a>permission stores</a> to
@@ -395,6 +398,51 @@ spec: webidl
     as a copy of the mappings of any other <a>permission store</a> associated
     with the <a>same origin</a>.
   </p>
+
+  <div class="example" id="example-permission-stores">
+    <p>
+      Different browsers provide different levels of persistence for
+      permissions. These can be modeled by different arrangements of permission
+      stores.
+    </p>
+    <ul>
+      <li>
+        A browser that saves permissions persistently would create a
+        <a>permission store</a> for each <a>origin</a> and for each
+        <a>realm</a>. Each realm's store would be created as a copy of its
+        origin's store. <a>create a permission storage entry</a> would write to
+        the origin's store and all realms' stores with the same origin.
+      </li>
+      <li>
+        A browser that gives the user the option to save permissions
+        persistently or not, would also create a <a>permission store</a> for
+        each <a>origin</a> and for each <a>realm</a>. If the user chooses to
+        save the permission, this browser would behave as the one above. If the
+        user chooses not to save the permission, this browser would select no
+        stores at all in <a>create a permission storage entry</a>.
+      </li>
+      <li>
+        A browser that gives the user the option to save permissions
+        either persistently or just within the current realm, would also create
+        a <a>permission store</a> for each <a>origin</a> and for each
+        <a>realm</a>. If the user chooses to save the permission, this browser
+        would behave as the ones above. If the user chooses not to save the
+        permission, this browser would select just the current realm's store in
+        <a>create a permission storage entry</a>.
+      </li>
+      <li>
+        A browser that treats permissions granted to iframes as only granted to
+        the iframe's origin when it's embedded in the same top-level origin,
+        would create permission stores for each pair of (top-level origin,
+        embedded origin), and for each realm. Each realm's store would be
+        created as a copy of the (top-level origin, realm's origin) permission
+        store. <a>create a permission storage entry</a> would write to the
+        (top-level origin, realm's origin) store and all realms' stores that had
+        matching origins and top-level origins, but not to permission stores
+        that merely had the same realm origin.
+      </li>
+    </ul>
+  </div>
 
   <pre class='idl'>
     dictionary PermissionStorage {


### PR DESCRIPTION
Each origin now gets its own store, and may have several to model
tab-specific or realm-specific grants.

Fixes #84 and fixes #86.

@raymeskhoury @jan-ivar @annevk, here's an attempt to handle temporary permissions by leaving the selection of where to read and write permission-grants up to the UA. What do you think?

https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/permissions/multiple-stores/index.bs