### PR TITLE
Describe the permission store using constraints instead of a full model.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,6 +27,7 @@ Markup Shorthands: css no, markdown yes
 spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
     type: dfn
         text: Realm; url: sec-code-realms
+        text: current realm; url: current-realm
     type: interface
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
@@ -37,12 +38,14 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 spec: html
     type: dfn
         text: browsing context
+        text: current settings object
         text: environment settings object
         text: event handler
         text: event handler event type
         text: origin
         text: parent browsing context
         text: queue a task
+        text: the realm's settings object
         text: top-level browsing context
 spec: ui-events
     type: dfn
@@ -371,17 +374,25 @@ spec: webidl
   <p>
     Each <a>realm</a> has a <dfn export>permission store</dfn> consisting of,
     for each {{PermissionName}}, either a <dfn><i>denied flag</i></dfn> or a set
-    of instances of that {{PermissionName}}'s <a>permission grant type</a>. The
-    UA may initialize and update a <a>realm</a>'s <a>permission store</a> almost
-    arbitrarily, subject to the constraints in <a
-    href="#permission-store-constraints"></a>.
+    of <dfn>permission entries</dfn>, instances of that {{PermissionName}}'s
+    <a>permission entry type</a>, which will be {{PermissionStorageEntry}} or
+    one of its subtypes. The <a>permission entry type</a> specifies the
+    <a>equivalent permission entry</a> relation used to de-duplicate the
+    <a>permission entries</a>.
+  </p>
 
-    Each web API that relies on user permission defines a <a>permission storage
-    type</a> which is {{PermissionStorageEntry}} or one of its subtypes. The UA
-    provides <a>read</a>, <a>write</a>, and <a>revoke</a> abstract operations
-    that let web APIs interact with the user's choices about how permission
-    decisions are remembered. The UA is <em>not</em> required to persist
-    permission decisions in any way.
+  <p>
+    The UA may initialize <a>realm</a>'s <a>permission store</a> almost
+    arbitrarily, subject to the constraints in <a
+    href="#permission-store-constraints"></a>. The UA may also <a>queue a
+    task</a> to update a <a>realm's</a> <a>permission store</a> almost
+    arbitrarily, also subject to the constraints in <a
+    href="#permission-store-constraints"></a>.
+  </p>
+
+  <p>
+    The UA may store <a>permission entries</a> more persistently than a
+    <a>realm</a>, but this specification doesn't constrain how.
   </p>
 
   <pre class='idl'>
@@ -393,134 +404,75 @@ spec: webidl
     };
   </pre>
 
-  <div algorithm="read-the-granted-permissions">
-    <p>
+  <section>
+    <h3 id="permission-store-algorithms">Permission store algorithms</h3>
+
+    <p algorithm="read-the-granted-permissions">
       When an algorithm says to <dfn export local-lt="read">read the granted
       permissions</dfn> that match a particular description, the UA must return
-      a set of instances of {{PermissionStorageEntry}} and its subtypes such
-      that:
+      the set of instances of {{PermissionStorageEntry}} and its subtypes in the
+      <a>current realm's</a> <a>permission store</a> that match the description.
+      <i><a>Denied flags</a></i> don't contribute any instances.
     </p>
-    <ul>
-      <li>each instance matches the description;</li>
-      <li>
-        each instance has the type of its {{PermissionStorageEntry/name}}
-        field's <a>permission storage type</a>; and
-      </li>
-      <li>
-        no two instances are equivalent, using {{PermissionStorageEntry/name}}'s
-        <a>permission entry equivalence</a> algorithm.
-      </li>
-      <li>
-        the set satisfies the constraints on call sequences described in <a
-        href="#permission-store-constraints"></a>.
-      </li>
-    </ul>
-  </div>
 
-  <p algorithm="permission-is-denied">
-    The |name| <dfn export>permission is denied</dfn> if the user has requested
-    not to be prompted for the |name| permission.
-  </p>
+    <p algorithm="permission-is-denied">
+      The |name| <dfn export>permission is denied</dfn> if the <a>current
+      realm's</a> <a>permission store</a> holds a <i><a>denied flag</a></i> for
+      |name|.
+    </p>
 
-  <p algorithm="write-the-permission-entry">
-    When an algorithm says to <dfn export local-lt="write">write the permission
-    entry</dfn> |entry|, that gives the UA the option to return |entry| from
-    future <a>reads</a> that would otherwise have returned another <a
-    lt="permission entry equivalence">equivalent</a> entry.
-  </p>
+    <p algorithm="write-the-permission-entry">
+      When an algorithm says to <dfn export local-lt="write">write the permission
+      entry</dfn> |entry|, the UA may add |entry| to the <a>current realm's</a>
+      <a>permission store</a>, overwriting any existing <a lt="equivalent
+      permission entry">equivalent</a> entries.
+    </p>
 
-  <p algorithm="revoke-the-permission-entries">
-    When an algorithm says to <dfn export local-lt="revoke">revoke the
-    permission entries</dfn> matching some description, the UA should avoid
-    returning matching entries from future <a lt="read the granted
-    permissions">reads</a>.
-  </p>
+    <p algorithm="revoke-the-permission-entries">
+      When an algorithm says to <dfn export local-lt="revoke">revoke the
+      permission entries</dfn> matching some description, the UA may remove those
+      <a>permission entries</a> from the <a>current realm's</a> <a>permission
+      store</a>.
+    </p>
+  </section>
 
   <section>
     <h3 id="permission-store-constraints">Permission store constraints</h3>
 
-    <p>
-      The UA may return nearly anything from <a>read the granted
-      permissions</a>, but there are a few constraints:
+    <p algorithm="relevant-permission-change">
+      A <dfn>relevant permission change</dfn> for one or more <a>realms</a> |realms|
+      consists of either the UA receiving new information about the user's
+      intent or a use of <a>write the permission entry</a> or <a>revoke the
+      permission entries</a> from a <a>realm</a> whose <a
+      lt="the Realm's settings object">settings object</a> has the <a>same
+      origin</a> as one of the |realms|.
+    </p>
+
+    <p class="issue" id="issue-same-domain-permissions">
+      It's not clear if some current browsers share permissions more widely than
+      a single origin. For example, when a user grants permission for
+      https://foo.com/ to use a capability, some browsers may also give access
+      to any origin with a domain ending in ".foo.com". This specification may
+      need to allow this.
     </p>
 
     <p>
-      Within a single <a>microtask checkpoint</a> in a <a>realm</a>, the
-      permission store must behave as a set of entries:
+      If two <a>realm</a> <a>permission stores</a> are created, and the time
+      between their creation doesn't include any <a>relevant permission
+      changes</a> for the realms, the two <a>permission stores</a> must have the
+      same contents.
     </p>
-    <ul>
-      <li>
-        If the |name| <a>permission is denied</a>, <a lt="read the granted
-        permissions">reading the granted permissions</a> with that |name| must
-        return an empty set.
-      </li>
-      <li>
-        <a lt="write the permission entry">Writing</a> |entry| must either have no effect or cause subsequent 
-      </li>
-    </ul>
+
+    <p>
+      The UA may only <a>queue a task</a> to update a <a>realm's</a>
+      <a>permission store</a> when a <a>relevant permission change</a> happens.
+    </p>
+
+    <p>
+      The specifications for individual {{PermissionName}}s can add additional
+      constraints.
+    </p>
   </section>
-
-  <p>
-    must  maintain a <dfn export>permission store</dfn> with three operations.
-    The permission store is a set of permission storage entries, which are instances of {{PermissionStorageEntry}} or one of its subtypes.
-    described <a lt='user agent'>User agents</a> MAY use a form of storage to
-    keep track of web site permissions. When they do, they MUST have a
-    <dfn export>permission storage identifier</dfn> which is linked to a
-    {{PermissionStorage}} instance or one of its subtypes.
-  </p>
-  <p>
-    To <dfn>get a permission storage identifier</dfn> for a
-    {{PermissionName}} <var>name</var> and an <a>environment settings
-    object</a> <var>settings</var>, the UA MUST return a tuple consisting
-    of:
-  </p>
-  <ol>
-    <li>
-      <var>name</var>
-    </li>
-    <li>
-      <var>settings</var>' <a>origin</a>
-    </li>
-    <li>optional UA-specific data like whether <var>settings</var>'
-    <a>browsing context</a> has a <a>parent browsing context</a>, or
-    <var>settings</var>' <a>top-level browsing context</a>'s <a>origin</a>
-    </li>
-  </ol>
-  <p>
-    The steps to <dfn>retrieve a permission storage entry</dfn> of a
-    <a>permission storage identifier</a> are as follows:
-  </p>
-  <ol>
-    <li>If the <a>user agent</a> has a {{PermissionStorage}} associated
-    with the <a>permission storage identifier</a> in its permission store,
-    it MUST return the {{PermissionStorage}}.
-    </li>
-    <li>Otherwise, it MUST return <code>undefined</code>.
-    </li>
-  </ol>
-  <p>
-    The steps to <dfn>create a permission storage entry</dfn> for a
-    <a>permission storage identifier</a> are as follows:
-  </p>
-  <ol>
-    <li>If the <a>user agent</a> has a {{PermissionStorage}} associated
-    with the <a>permission storage identifier</a> in its permission store,
-    it MUST overwrite it to the given {{PermissionStorage}}.
-    </li>
-    <li>Otherwise, it MUST write the new {{PermissionStorage}} to its
-    permission store.
-    </li>
-  </ol>
-  <p>
-    The steps to <dfn>delete a permission storage entry</dfn> of a
-    <a>permission storage identifier</a> are as follows:
-  </p>
-  <ol>
-    <li>If the <a>user agent</a> has a {{PermissionStorage}} associated
-    with the <a>permission storage identifier</a> in its permission store,
-    it MUST remove it.
-    </li>
-  </ol>
 </section>
 <section>
   <h2 id="status-of-a-permission">

--- a/index.bs
+++ b/index.bs
@@ -25,6 +25,8 @@ Markup Shorthands: css no, markdown yes
 </pre>
 <pre class="anchors">
 spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
+    type: dfn
+        text: Realm; url: sec-code-realms
     type: interface
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
@@ -365,11 +367,103 @@ spec: webidl
   </section>
 </section>
 <section>
-  <h2 dfn-type="dfn" export>
-    Permission Store
-  </h2>
+  <h2 id="permission-stores">Permission stores</h2>
   <p>
-    <a lt='user agent'>User agents</a> MAY use a form of storage to
+    Each <a>realm</a> has a <dfn export>permission store</dfn> consisting of,
+    for each {{PermissionName}}, either a <dfn><i>denied flag</i></dfn> or a set
+    of instances of that {{PermissionName}}'s <a>permission grant type</a>. The
+    UA may initialize and update a <a>realm</a>'s <a>permission store</a> almost
+    arbitrarily, subject to the constraints in <a
+    href="#permission-store-constraints"></a>.
+
+    Each web API that relies on user permission defines a <a>permission storage
+    type</a> which is {{PermissionStorageEntry}} or one of its subtypes. The UA
+    provides <a>read</a>, <a>write</a>, and <a>revoke</a> abstract operations
+    that let web APIs interact with the user's choices about how permission
+    decisions are remembered. The UA is <em>not</em> required to persist
+    permission decisions in any way.
+  </p>
+
+  <pre class='idl'>
+    dictionary PermissionStorageEntry {
+      // PermissionStorage is just an explanatory device.
+      // Instances are never received from or passed to Javascript code.
+
+      required PermissionName name;
+    };
+  </pre>
+
+  <div algorithm="read-the-granted-permissions">
+    <p>
+      When an algorithm says to <dfn export local-lt="read">read the granted
+      permissions</dfn> that match a particular description, the UA must return
+      a set of instances of {{PermissionStorageEntry}} and its subtypes such
+      that:
+    </p>
+    <ul>
+      <li>each instance matches the description;</li>
+      <li>
+        each instance has the type of its {{PermissionStorageEntry/name}}
+        field's <a>permission storage type</a>; and
+      </li>
+      <li>
+        no two instances are equivalent, using {{PermissionStorageEntry/name}}'s
+        <a>permission entry equivalence</a> algorithm.
+      </li>
+      <li>
+        the set satisfies the constraints on call sequences described in <a
+        href="#permission-store-constraints"></a>.
+      </li>
+    </ul>
+  </div>
+
+  <p algorithm="permission-is-denied">
+    The |name| <dfn export>permission is denied</dfn> if the user has requested
+    not to be prompted for the |name| permission.
+  </p>
+
+  <p algorithm="write-the-permission-entry">
+    When an algorithm says to <dfn export local-lt="write">write the permission
+    entry</dfn> |entry|, that gives the UA the option to return |entry| from
+    future <a>reads</a> that would otherwise have returned another <a
+    lt="permission entry equivalence">equivalent</a> entry.
+  </p>
+
+  <p algorithm="revoke-the-permission-entries">
+    When an algorithm says to <dfn export local-lt="revoke">revoke the
+    permission entries</dfn> matching some description, the UA should avoid
+    returning matching entries from future <a lt="read the granted
+    permissions">reads</a>.
+  </p>
+
+  <section>
+    <h3 id="permission-store-constraints">Permission store constraints</h3>
+
+    <p>
+      The UA may return nearly anything from <a>read the granted
+      permissions</a>, but there are a few constraints:
+    </p>
+
+    <p>
+      Within a single <a>microtask checkpoint</a> in a <a>realm</a>, the
+      permission store must behave as a set of entries:
+    </p>
+    <ul>
+      <li>
+        If the |name| <a>permission is denied</a>, <a lt="read the granted
+        permissions">reading the granted permissions</a> with that |name| must
+        return an empty set.
+      </li>
+      <li>
+        <a lt="write the permission entry">Writing</a> |entry| must either have no effect or cause subsequent 
+      </li>
+    </ul>
+  </section>
+
+  <p>
+    must  maintain a <dfn export>permission store</dfn> with three operations.
+    The permission store is a set of permission storage entries, which are instances of {{PermissionStorageEntry}} or one of its subtypes.
+    described <a lt='user agent'>User agents</a> MAY use a form of storage to
     keep track of web site permissions. When they do, they MUST have a
     <dfn export>permission storage identifier</dfn> which is linked to a
     {{PermissionStorage}} instance or one of its subtypes.
@@ -392,14 +486,6 @@ spec: webidl
     <var>settings</var>' <a>top-level browsing context</a>'s <a>origin</a>
     </li>
   </ol>
-  <pre class='idl'>
-    dictionary PermissionStorage {
-      // PermissionStorage is just an explanatory device.
-      // Instances are never received from or passed to Javascript code.
-
-      required PermissionState state;
-    };
-  </pre>
   <p>
     The steps to <dfn>retrieve a permission storage entry</dfn> of a
     <a>permission storage identifier</a> are as follows:

--- a/index.bs
+++ b/index.bs
@@ -374,11 +374,12 @@ spec: webidl
   <p>
     Each <a>realm</a> has a <dfn export>permission store</dfn> consisting of,
     for each {{PermissionName}}, either a <dfn><i>denied flag</i></dfn> or a set
-    of <dfn>permission entries</dfn>, instances of that {{PermissionName}}'s
-    <a>permission entry type</a>, which will be {{PermissionStorageEntry}} or
-    one of its subtypes. The <a>permission entry type</a> specifies the
-    <a>equivalent permission entry</a> relation used to de-duplicate the
-    <a>permission entries</a>.
+    of <a>permission entries</a>. <dfn>Permission entries</dfn> for a
+    {{PermissionName}} are instances of that {{PermissionName}}'s <a>permission
+    entry type</a>, which will be {{PermissionStorageEntry}} or one of its
+    subtypes. The <a>permission entry type</a> specifies the <a>equivalent
+    permission entry</a> relation used to de-duplicate the <a>permission
+    entries</a>.
   </p>
 
   <p>
@@ -410,8 +411,8 @@ spec: webidl
     <p algorithm="read-the-granted-permissions">
       When an algorithm says to <dfn export local-lt="read">read the granted
       permissions</dfn> that match a particular description, the UA must return
-      the set of instances of {{PermissionStorageEntry}} and its subtypes in the
-      <a>current realm's</a> <a>permission store</a> that match the description.
+      the <a>permission entries</a> that match the description in the <a>current
+      realm's</a> <a>permission store</a> that match the description.
       <i><a>Denied flags</a></i> don't contribute any instances.
     </p>
 

--- a/index.bs
+++ b/index.bs
@@ -153,11 +153,20 @@ spec: webidl
       If unspecified, this defaults to {{PermissionDescriptor}}.
     </dd>
     <dt>
-      A <dfn export>permission storage type</dfn>
+      A <dfn export>permission entry type</dfn>
     </dt>
     <dd>
-      {{PermissionStorage}} or one of its subtypes.
-      If unspecified, this defaults to {{PermissionStorage}}.
+      {{PermissionStorageEntry}} or one of its subtypes.
+      If unspecified, this defaults to {{PermissionStorageEntry}}.
+    </dd>
+    <dt>
+      An <dfn export>equivalent permission entry</dfn> relation
+    </dt>
+    <dd>
+      An equivalence relation on instances of the <a>permission entry type</a>.
+      If two instances are equivalent, they can't be stored in a <a>permission
+      store</a> at the same time. If unspecified, this defaults to comparing the
+      {{PermissionStorageEntry/name}} fields.
     </dd>
     <dt>
       A <dfn export>permission result type</dfn>
@@ -170,41 +179,42 @@ spec: webidl
       A <dfn export>permission query algorithm</dfn>
     </dt>
     <dd>
-      Takes an instance of the <a>permission descriptor type</a>,
-      an instance of the <a>permission storage type</a> that's currently
-      stored for this <a>permission</a>, and a new or existing instance of
-      the <a>permission result type</a>, and updates the <a>permission
-      result type</a> instance with the query result. Used by
-      {{Permissions}}' {{Permissions/query()}}
-      method and the <a href="#PermissionStatus-update">PermissionStatus
-      update steps</a>. If unspecified, this defaults to the <a>boolean
-      permission query algorithm</a>.
+      Takes an instance of the <a>permission descriptor type</a> |descriptor|
+      and a new or existing instance of the <a>permission result type</a>
+      |result|, and updates |result| with the query result. This algorithm needs
+      to <a>read the granted permissions</a> corresponding to the meaning of
+      |descriptor| to find what permission the user has granted. Used by
+      {{Permissions}}' {{Permissions/query()}} method and the <a
+      href="#PermissionStatus-update">PermissionStatus update steps</a>. If
+      unspecified, this defaults to the <a>boolean permission query
+      algorithm</a>.
     </dd>
     <dt>
       A <dfn export>permission request algorithm</dfn>
     </dt>
     <dd>
-      Takes the previously-stored instance of the <a>permission storage
-      type</a>, an instance of the <a>permission descriptor type</a>,
-      and a newly-created instance of the <a>permission result type</a>.
-      Shows the user any necessary prompt to try to increase permissions,
-      and updates the instances of the <a>permission storage type</a> and
-      <a>permission result type</a> to match. May return a {{Promise}}
-      if the request can fail exceptionally. (Merely being denied
-      permission is not exceptional.) Used by {{Permissions}}'
-      {{Permissions/request()}} method, which handles
-      reading and writing the <a>permission store</a>. If unspecified, this
+      Takes an instance of the <a>permission descriptor type</a> |descriptor|,
+      and a newly-created instance of the <a>permission result type</a>
+      |result|. If |descriptor| requests permissions that haven't yet been
+      either <a lt="read">granted</a> or <a lt="denied flag">denied</a>, shows
+      the user a prompt to ask for their permission. Then <a>writes</a> the
+      result of that prompt back to the <a>permission store</a> and updates
+      |result| to match. May return a {{Promise}} if the request can fail
+      exceptionally. (Merely being denied permission is not exceptional.) Used
+      by {{Permissions}}' {{Permissions/request()}} method. If unspecified, this
       defaults to the <a>boolean permission request algorithm</a>.
     </dd>
     <dt>
       A <dfn export>permission revocation algorithm</dfn>
     </dt>
     <dd>
-      Takes no arguments. Updates any other parts of the implementation
-      that need to be kept in sync after an entry is removed from the
-      permission store. Triggered by {{Permissions}}'
-      {{Permissions/revoke()}} method. If unspecified, this
-      defaults to doing nothing.
+      Takes an instance of the <a>permission descriptor type</a> |descriptor|.
+      <a>Revokes</a> or <a>writes</a> any <a>permission entries</a> necessary to
+      indicate that the user no longer gives permission corresponding to the
+      meaning of |descriptor|. Also updates any other parts of the
+      implementation that need to be kept in sync with these changes. Triggered
+      by {{Permissions}}' {{Permissions/revoke()}} method. If unspecified, this
+      defaults to the <a>boolean permission revocation algorithm</a>.
     </dd>
   </dl>
   <p>
@@ -313,7 +323,7 @@ spec: webidl
         </p>
       </dd>
       <dt>
-        <a>permission storage type</a>
+        <a>permission entry type</a>
       </dt>
       <dd>
         TODO
@@ -373,7 +383,7 @@ spec: webidl
   <h2 id="permission-stores">Permission stores</h2>
   <p>
     Each <a>realm</a> has a <dfn export>permission store</dfn> consisting of,
-    for each {{PermissionName}}, either a <dfn><i>denied flag</i></dfn> or a set
+    for each {{PermissionName}}, either a <dfn>denied flag</dfn> or a set
     of <a>permission entries</a>. <dfn>Permission entries</dfn> for a
     {{PermissionName}} are instances of that {{PermissionName}}'s <a>permission
     entry type</a>, which will be {{PermissionStorageEntry}} or one of its
@@ -413,12 +423,12 @@ spec: webidl
       permissions</dfn> that match a particular description, the UA must return
       the <a>permission entries</a> that match the description in the <a>current
       realm's</a> <a>permission store</a> that match the description.
-      <i><a>Denied flags</a></i> don't contribute any instances.
+      <a>Denied flags</a> don't contribute any instances.
     </p>
 
     <p algorithm="permission-is-denied">
       The |name| <dfn export>permission is denied</dfn> if the <a>current
-      realm's</a> <a>permission store</a> holds a <i><a>denied flag</a></i> for
+      realm's</a> <a>permission store</a> holds a <a>denied flag</a> for
       |name|.
     </p>
 
@@ -434,6 +444,12 @@ spec: webidl
       permission entries</dfn> matching some description, the UA may remove those
       <a>permission entries</a> from the <a>current realm's</a> <a>permission
       store</a>.
+    </p>
+
+    <p>
+      There are no algorithms to set the <a>denied flag</a>. It's
+      expected that UAs will set this in response to user action outside the
+      scope of web standards.
     </p>
   </section>
 
@@ -462,6 +478,13 @@ spec: webidl
       between their creation doesn't include any <a>relevant permission
       changes</a> for the realms, the two <a>permission stores</a> must have the
       same contents.
+    </p>
+
+    <p>
+      If some <a>permission entries</a> are <a>revoked</a> and then a new
+      <a>permission store</a> is created, without the UA receiving any new
+      information about the user's intent or any <a>writes</a> of those entries,
+      the new <a>permission store</a> must not include those entries.
     </p>
 
     <p>
@@ -503,28 +526,7 @@ spec: webidl
     will be asking the user's permission if the caller tries to access the
     feature. The user might grant, deny or dismiss the request.
   </p>
-  <p>
-    The steps to <dfn export>retrieve the permission storage</dfn> for a given
-    {{PermissionName}} <var>name</var> are as follows:
-  </p>
-  <ol>
-    <li>
-      <a>Get a permission storage identifier</a> for <var>name</var> and
-      the current <a>environment settings object</a>, and let
-      <var>identifier</var> be the result.
-    </li>
-    <li>Run the steps to <a>retrieve a permission storage entry</a> of
-    <var>identifier</var>.
-    </li>
-    <li>If the result of those steps are not <code>undefined</code>, return
-    it and abort these steps.
-    </li>
-    <li>Otherwise, the <a>user agent</a> MUST return a default value based
-    on <a>user agent</a>'s defined heuristics. For example, <code>{state:
-    {{"prompt"}}}</code> can be a default value, but it can also be based on
-    frequency of visits.
-    </li>
-  </ol>
+
   <pre class='idl'>
     [Exposed=(Window,Worker)]
     interface PermissionStatus : EventTarget {
@@ -557,13 +559,9 @@ spec: webidl
     follows:
   </p>
   <ol>
-    <li>Run the steps to <a>retrieve the permission storage</a> for
-      <code><var>status</var>@{{[[query]]}}.{{PermissionDescriptor/name}}</code>,
-      and let <var>storage</var> be the result.
-    </li>
     <li>Run <code><var>status</var>@{{[[permission]]}}</code>'s <a>permission
-    query algorithm</a>, passing <code><var>status</var>@{{[[query]]}}</code>,
-    <var>storage</var>, and <var>status</var>.
+    query algorithm</a>, passing <code><var>status</var>@{{[[query]]}}</code>
+    and <var>status</var>.
     </li>
   </ol>
   <p>
@@ -710,8 +708,7 @@ spec: webidl
   </div>
   <p>
     When the <dfn for='Permissions' method>request()</dfn> method is invoked,
-    the <a>user agent</a> MUST run the following <dfn export>request a
-    permission</dfn> algorithm, passing the parameter
+    the <a>user agent</a> MUST run the following algorithm, passing the parameter
     <var>permissionDesc</var>:
   </p>
   <ol class="algorithm">
@@ -741,25 +738,19 @@ spec: webidl
     <li>Run the steps to <a>create a PermissionStatus</a> for
     <var>permissionDesc</var>, and let <var>status</var> be the result.
     </li>
-    <li>Run the steps to <a>retrieve the permission storage</a> for
-    <var>permission</var>, and let <var>storage</var> be the result.
-    </li>
     <li>Let <var>result</var> be the result of <a>promise-calling</a>
       <var>permission</var>'s <a>permission request algorithm</a> with
-      <var>storage</var>, <var>permissionDesc</var>, and <var>status</var>
+      <var>permissionDesc</var>, and <var>status</var>
       as arguments.
+
+      <p class="note">
+        The <a>permission request algorithm</a> is responsible for <a
+        lt="read">checking if permission is already granted</a>, prompting the
+        user, and <a>writing</a> the result back to storage.
+      </p>
     </li>
     <li>Resolve <var>promise</var> with the result of <a>transforming</a>
-    <var>result</var> with a fulfillment handler that runs the following
-    steps.
-    </li>
-    <li>
-      <a>Get a permission storage identifier</a> for
-      <code><var>permissionDesc</var>.name</code> and the current
-      <a>environment settings object</a>, and <a>create a permission
-      storage entry</a> mapping this identifier to <var>storage</var>.
-    </li>
-    <li>Return <var>status</var>.
+    <var>result</var> with a fulfillment handler that returns |status|.
     </li>
   </ol>
   <p>
@@ -789,17 +780,8 @@ spec: webidl
     <li>Return <var>promise</var> and continue the following steps
     asynchronously.
     </li>
-    <li>
-      <a>Get a permission storage identifier</a> for
-      <code><var>permission</var>.name</code> and the current
-      <a>environment settings object</a>, and let <var>identifier</var> be
-      the result.
-    </li>
-    <li>Run the steps to <a>delete a permission storage entry</a> using
-    <var>identifier</var>.
-    </li>
     <li>Run <code><var>permissionDesc</var>.name</code>'s <a>permission revocation
-    algorithm</a>.
+    algorithm</a> with |permissionDesc| as its argument.
     </li>
     <li>Run the steps to <a>create a PermissionStatus</a> for
     <var>permissionDesc</var>, and let <var>status</var> be the result.
@@ -816,22 +798,73 @@ spec: webidl
   </h2>
   <p>
     The <dfn export>boolean permission query algorithm</dfn>, given a
-    {{PermissionDescriptor}} <var>permissionDesc</var>, a
-    {{PermissionStorage}} <var>storage</var>, and a
+    {{PermissionDescriptor}} <var>permissionDesc</var> and a
     {{PermissionStatus}} <var>status</var>, runs the following steps:
   </p>
   <ol class="algorithm">
-    <li>Set <code><var>status</var>.state</code> to
-    <code><var>storage</var>.state</code>
+    <li>
+      Let |name| be <code>|permissionDesc|.{{PermissionDescriptor/name}}</code>.
+    </li>
+    <li>
+      If the |name| <a>permission is denied</a>, set <code>|status|.state</code>
+      to {{"denied"}} and abort these steps.
+    </li>
+    <li>
+      <a>Read the granted permissions</a> with a {{PermissionStorageEntry/name}}
+      equal to <code>|permissionDesc|.name</code>, and let |grants| be the
+      result.
+    </li>
+    <li>
+      If |grants| is empty, set <code>|status|.state</code> to {{"prompt"}}.
+      Otherwise, set it to {{"granted"}}.
     </li>
   </ol>
   <p>
     The <dfn export>boolean permission request algorithm</dfn>, given a
-    {{PermissionDescriptor}} <var>permission</var> and a
-    {{PermissionStatus}} <var>status</var>, runs the following steps:
+    {{PermissionDescriptor}} |permissionDesc| and a
+    {{PermissionStatus}} |status|, runs the following steps:
   </p>
   <ol class="algorithm">
-    <li>TODO
+    <li>
+      Run the <a>boolean permission query algorithm</a> on |permissionDesc| and
+      |status|.
+    </li>
+    <li>
+      If <code>|status|.state</code> is not {{"prompt"}}, abort these steps.
+    </li>
+    <li>
+      Prompt the user to request that the <a>current settings object</a>'s
+      <a>origin</a> be given permission to access the capability named
+      <code>|permissionDesc|.{{PermissionDescriptor/name}}</code>.
+    </li>
+    <li>
+      If the user grants permission, <a>write the permission entry</a>
+      <code>{<a idl for="PermissionStorageEntry">name</a>:
+      |permissionDesc|.{{PermissionDescriptor/name}}}</code>.
+    </li>
+    <li>
+      Run the <a>boolean permission query algorithm</a> again on
+      |permissionDesc| and |status|.
+
+      <p class="issue" id="issue-non-persistent-grants">
+        On browsers that don't store permissions persistently within a
+        <a>realm</a>, this will always return {{"prompt"}}, but still show the
+        user an unnecessary prompt. That may mean that no permissions should use
+        the <a>boolean permission request algorithm</a>, since it can never
+        return an appropriate object-capability.
+      </p>
+    </li>
+  </ol>
+
+  <p>
+    The <dfn export>boolean permission revocation algorithm</dfn>, given a
+    {{PermissionDescriptor}} |permissionDesc|, runs the following steps:
+  </p>
+  <ol class="algorithm">
+    <li>
+      <a>Revoke the permission entries</a> that have a
+      {{PermissionStorageEntry/name}} equal to
+      <code>|permissionDesc|.{{PermissionDescriptor/name}}</code>.
     </li>
   </ol>
 </section>


### PR DESCRIPTION
Here's a third attempt at modeling the permission store, as an alternative to #95, based on @raymeskhoury's suggestions.

This says that each realm has a permission store that's a set of entries for each capability, or a flag saying that capability is denied. The UA gets to ignore writes if it wants and can post tasks to update a realm's store when it ["receives new information about the user’s intent"](https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/permissions/set-permission-store/index.bs#relevant-permission-change), but each particular capability can add constraints on these updates.

Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/permissions/set-permission-store/index.bs#permission-stores

@alvestrand, this removes the "request a permission" entry point, because it's now straightforward to read and write the current permission store directly. We might want to add a "prompt the user to choose between several options" to match what you're using in [`getUserMedia()`](http://w3c.github.io/mediacapture-main/getusermedia.html#dom-mediadevices-getusermedia) step 7. The old algorithm didn't return a `MediaStream` anyway as step 8 expects. I think that should be a separate change.

@martinthomson @annevk

Fixes #84 and fixes #86.