### PR TITLE
chore(navigator-and-workernavigator-extension): remove redudant text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -722,10 +722,6 @@ spec: webidl
   <h2 id="navigator-and-workernavigator-extension">
     Navigator and WorkerNavigator extension
   </h2>
-  <p>
-    A {{Permissions}} instance is exposed on the <code>navigator</code>
-    object for {{Window}} and {{Worker}} contexts.
-  </p>
   <pre class='idl'>
     [Exposed=(Window)]
     partial interface Navigator {


### PR DESCRIPTION
This text is redundant: the IDL already states this. 