### PR TITLE
chore(editors): add W3C editor IDs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,9 +7,9 @@ TR: https://www.w3.org/TR/permissions/
 Shortname: permissions
 Level: 1
 Group: webappsec
-Editor: Mounir Lamouri, Google Inc. https://google.com/
-Editor: Marcos Cáceres, Mozilla https://mozilla.com/
-Editor: Jeffrey Yasskin, Google Inc. https://google.com/
+Editor: Mounir Lamouri, w3cid 45389, Google Inc. https://google.com/
+Editor: Marcos Cáceres, w3cid 39125, Mozilla https://mozilla.com/
+Editor: Jeffrey Yasskin, w3cid 72192, Google Inc. https://google.com/
 
 Abstract: The <cite>Permissions Standard</cite> defines common infrastructure for other specifications that need to interact with browser permissions. It also defines an API to allow web applications to query and request changes to the status of a given permission.
 Mailing List: public-webappsec@w3.org


### PR DESCRIPTION
These were lost in the Bikeshed conversion because I didn't realize
Bikeshed let us specify them (tabatkins/bikeshed#362).

@marcoscaceres 