### PR TITLE
feat(prompts): allow UAs to deny non-gesture prompts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -48,6 +48,7 @@ spec: html
         text: in parallel
         text: origin; for: /
         text: queue a task
+        text: triggered by user activation
 spec: ui-events
     type: dfn
         text: user agent
@@ -290,6 +291,10 @@ spec: webidl
           <var>current state</var> and abort these steps.
         </li>
         <li>
+          If this algorithm is not <a>triggered by user activation</a>,
+          the UA may return {{"denied"}} and abort these steps.
+        </li>
+        <li>
           Ask the user's permission for the calling algorithm to use the
           <a>powerful feature</a> described by |descriptor|.
         </li>
@@ -335,6 +340,10 @@ spec: webidl
           choose">prompts for the user to choose</a> from the same set of
           options with the same |descriptor| must return the same option, unless
           the UA receives <a>new information about the user's intent</a>.
+        </li>
+        <li>
+          If this algorithm is not <a>triggered by user activation</a>,
+          the UA may return {{"denied"}} and abort these steps.
         </li>
         <li>
           Ask the user to choose one of the options or deny permission, and wait


### PR DESCRIPTION
Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/permissions/gesture-may-gate-prompt/index.bs#requesting-more-permission

This allows a UA to leave the permission state at "prompt" but deny
permission requests that weren't triggered from a user gesture without
prompting the user. We don't require UAs to deny these prompts because
it would cause non-persistent permissions to require two click in
some flows that Firefox folks think should only require one click.

Fixes #77.

@mnoorenberghe @noncombatant @jan-ivar @benfredwells @martinthomson


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/permissions/pull/107.html" title="Last updated on Feb 16, 2021, 11:20 PM UTC (819bd27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/107/f9efa43...jyasskin:819bd27.html" title="Last updated on Feb 16, 2021, 11:20 PM UTC (819bd27)">Diff</a>