### PR TITLE
feat(algorithms): allow calling with a PermissionName

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -242,6 +242,12 @@ spec: webidl
         href="https://html.spec.whatwg.org/multipage/webappapis.html#realms-settings-objects-global-objects">several
         possible settings objects</a> it uses.
       </p>
+
+      <p>
+        As a shorthand, a {{PermissionName}} |name|'s <a>permission state</a> is
+        the <a>permission state</a> of a {{PermissionDescriptor}} with its
+        {{PermissionDescriptor/name}} member set to |name|.
+      </p>
     </div>
 
     <div algorithm>
@@ -312,6 +318,13 @@ spec: webidl
           </p>
         </li>
       </ol>
+
+      <p>
+        As a shorthand, <a>requesting permission to use</a> a {{PermissionName}}
+        |name|, is the same as <a>requesting permission to use</a> a
+        {{PermissionDescriptor}} with its {{PermissionDescriptor/name}} member
+        set to |name|.
+      </p>
     </div>
 
     <div algorithm="prompt-user-to-choose">
@@ -353,6 +366,14 @@ spec: webidl
           </p>
         </li>
       </ol>
+
+      <p>
+        As a shorthand, <a>prompting the user to choose</a> from options
+        associated with a {{PermissionName}} |name|, is the same as <a>prompting
+        the user to choose</a> from those options associated with a
+        {{PermissionDescriptor}} with its {{PermissionDescriptor/name}} member
+        set to |name|.
+      </p>
     </div>
   </section>
   <section>


### PR DESCRIPTION
Instead of forcing specs for simple permissions to write out a permission
descriptor. This partially fixes @annevk's objection that writing `{name: "persistent-storage"}` in a spec doesn't formally create a WebIDL dictionary instance, although we'll still need to formalize syntax like that for more complicated descriptors.

Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/permissions/permission-name-shorthand/index.bs#reading-current-states. I'm not sure the best place to define this. I want folks who click the link to, say, https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/permissions/permission-name-shorthand/index.bs#request-permission-to-use to find the definitions of the shorthands (so a separate "shorthands" section is out), and I don't want to make every spec write out `<a for="PermissionName">request permission to use</a>` to disambiguate the two definitions (so direct links to the shorthand are out). The wording doesn't fit well right next to the main definition, so I put it below.