### PR TITLE
fix(request): clarify how requests affect state

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -305,10 +305,9 @@ spec: webidl
         </li>
         <li>
           If the user grants permission, return {{"granted"}}; otherwise return
-          {{"denied"}}. If the user's interaction indicates they intend this
-          choice to apply to other realms, then treat this as <a>new information
-          about the user's intent</a> for other <a>realms</a> with the <a>same
-          origin</a>.
+          {{"denied"}}. The user's interaction may provide <a>new information
+          about the user's intent</a> for this <a>realm</a> and other
+          <a>realms</a> with the <a>same origin</a>.
 
           <p class="note">
             This is intentionally vague about the details of the permission UI


### PR DESCRIPTION
The old wording implied that the user's response to a prompt always
provided "new information" and so would be likely to affect the
permission state, but that interpretation wasn't intended.

The restriction to the same origin also doesn't match what browsers
actually do, especially with respect to ports, but we should fix that in
a separate change.

Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/permissions/clarify-request-not-imply-state/index.bs#request-permission-to-use

@jan-ivar 