### PR TITLE
chore(perm interface): Fix return value handling

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -580,14 +580,14 @@ spec: webidl
   <ol>
     <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to
     an IDL value</a> of type {{PermissionDescriptor}}. If this throws an
-    exception, return <a>a promise rejected with</a> that exception and abort
-    these steps.
+    exception, <a>reject</a> |promise| with that exception and abort these
+    steps.
     </li>
     <li>Let |typedDescriptor| be the object |permissionDesc| refers to,
     <a>converted to an IDL value</a> of
     <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s <a>permission
-    descriptor type</a>. If this throws an exception, return <a>a promise
-    rejected with</a> that exception and abort these steps.
+    descriptor type</a>. If this throws an exception, <a>reject</a> |promise|
+    with that exception and abort these steps.
     </li>
     <li>The UA now has <a lt="new information about the user's intent">new
     information that the user intends</a> to revoke permission to use the


### PR DESCRIPTION
Unlike the other methods defined in this section, `revoke` is defined as
a series of steps to be run in parallel. Returning a value is
meaningless in this context. Instead, the result of the operation should
be communicated via the Promise instance that is defined and
synchronously returned prior to the parallelized steps.