### PR TITLE
chore(example): Escape special character

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1152,7 +1152,7 @@ spec: webidl
       })
       // log the state or each camera
       .then(results => results.forEach(
-        ({ state }, i) => console.log(`Camera ${i}: "${state}"`)
+        ({ state }, i) => console.log(\`Camera ${i}: "${state}"\`)
       ))
       .catch(
         err => console.error(err.stack)


### PR DESCRIPTION
Ensure that the ECMAScript template delimiter (i.e. the "backtick"
character) is included in the rendered output.