### PR TITLE
Introduce "Automation" section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,7 +44,19 @@ spec: sensors; urlPrefix: https://w3c.github.io/sensors/#
 spec: manifest; urlPrefix: https://w3c.github.io/manifest/#
     type: dfn
         text: install; url: dfn-install
-
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
+    type: dfn
+        text: current browsing context; url: dfn-current-browsing-context
+        text: WebDriver error; url: dfn-error
+        text: WebDriver error code; url: dfn-error-code
+        text: extension command; url: dfn-extension-commands
+        text: extension command name; url: dfn-extension-command-name
+        text: extension command prefix; url: dfn-extension-command-prefix
+        text: invalid argument; url: dfn-invalid-argument
+        text: local end; url: dfn-local-end
+        text: remote end steps; url: dfn-remote-end-steps
+        text: session; url: dfn-session
+        text: success; url: dfn-success
 </pre>
 <pre class="link-defaults">
 spec: dom
@@ -60,6 +72,10 @@ spec: html
 spec: storage
     type: enum-value
         for: PermissionName; text: "persistent-storage"
+spec: infra
+    type: dfn
+        text: list
+        for: list; text: append
 spec: ui-events
     type: dfn
         text: user agent
@@ -972,6 +988,119 @@ spec: webidl
       permission is the permission associated with the usage of the
       asynchronous methods in the [[clipboard-apis]].
     </p>
+  </section>
+</section>
+<section>
+  <h2 id="automation">
+    Automation
+  </h2>
+  <p>
+    For the purposes of user-agent automation and application testing, this
+    document defines the following <a>extension command</a> for the
+    [[WebDriver]] specification.
+  </p>
+
+  <pre class='idl'>
+    dictionary PermissionSetParameters {
+      required PermissionDescriptor descriptor;
+      required PermissionState state;
+      boolean oneRealm = false;
+    };
+  </pre>
+
+  <section>
+    <h3 id="set-permission-command">
+      Set Permission
+    </h3>
+    <table>
+      <tbody>
+        <tr>
+          <th>HTTP Method</th>
+          <th><a lt="extension command prefix">Prefix</a></th>
+          <th><a lt="extension command name">Name</a></th>
+        </tr>
+        <tr>
+          <td>POST</td>
+          <td>/session/{session id}/permissions</td>
+          <td>set</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>The <dfn>Set Permission</dfn> <a>extension command</a> simulates user
+    modification of a {{PermissionDescriptor}}'s <a>permission state</a>.</p>
+    <p>The <a>remote end steps</a> are:</p>
+    <ol>
+      <li>Let |parameters| be the |parameters| argument, <a>converted to an IDL
+        value</a> of type {{PermissionSetParameters}}. If this throws an
+        exception, return a <a>WebDriver error</a> with <a>WebDriver error
+        code</a> <a>invalid argument</a>.
+      <li>Let |rootDesc| be
+        |parameters|.{{PermissionSetParameters/descriptor}}.</li>
+      <li>Let |typedDescriptor| be the object |rootDesc| refers to,
+        <a>converted to an IDL value</a> of
+        <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s <a>permission
+        descriptor type</a>. If this throws an exception, return a <a>WebDriver
+        error</a> with <a>WebDriver error code</a> <a>invalid
+        argument</a>.</li>
+      <li>If |parameters|.{{PermissionSetParameters/state}} is an inappropriate
+        <a>permission state</a> for any implementation-defined reason, return a
+        <a>WebDriver error</a> with <a>WebDriver error code</a> <a>invalid
+        argument</a>.
+        <p class="note">
+          For example, <a>user agents</a> that define the {{"midi"}}
+          <a>feature</a> as "always on" may choose to reject command
+          to set the <a>permission state</a> to {{"denied"}} at this step.
+        </p>
+      </li>
+      <li>Let |settings| be the <a>environment settings object</a> of the
+        <a>current browsing context</a>'s <a>active document</a>.</li>
+      <li>If |settings| is a <a>non-secure context</a> and
+        <code>|rootDesc|.{{PermissionDescriptor/name}}</code> isn't <a>allowed
+        in non-secure contexts</a>, return a <a>WebDriver error</a> with
+        <a>WebDriver error code</a> <a>invalid argument</a>.</li>
+      <li>If |parameters|.{{PermissionSetParameters/oneRealm}} is true, let
+        |targets| be a <a>list</a> whose sole member is |settings|.</li>
+      <li>Otherwise, let |targets| be a <a>list</a> containing all
+        <a>environment settings objects</a> whose [=environment settings
+        object/origin=] is the <a lt="same origin">same</a> as the
+        [=environment settings object/origin=] of |settings|.</li>
+      </li>
+      <li>Let |tasks| be an empty <a>list</a>.
+      <li>
+        For each <a>environment settings object</a> |target| in |targets|:
+        <ol>
+          <li><a>Queue a task</a> |task| on the <a>permission task source</a>
+            of |target|'s [=environment settings object/responsible browsing
+            context=] to perform the following step:</li>
+            <ol>
+            <li>Interpret |parameters|.{{PermissionSetParameters/state}} as if
+              it were the result of an invocation of <a>permission state</a>
+              for |typedDescriptor| with the argument |target| made at this
+              moment.</li>
+            </ol>
+          </li>
+          <li><a>Append</a> |task| to |tasks|.</li>
+        </ol>
+      </li>
+      <li>Wait for all <a>tasks</a> in |tasks| to have executed.</li>
+      <li>Return <a>success</a> with data `null`.</li>
+    </ol>
+    <div class="example">
+      To set permission for <code>{name: {{"midi"}}, sysex: true}</code> of the
+      <a>current browsing context</a> of the <a>session</a> with ID 23 to
+      "`granted`", the <a>local end</a> would POST to
+      `/session/23/permissions/set` with the body:
+
+      <pre class="lang-json">
+      {
+        "descriptor": {
+          "name": "midi",
+          "sysex": true
+        },
+        "state": "granted"
+      }
+      </pre>
+    </div>
   </section>
 </section>
 <section class='non-normative'>


### PR DESCRIPTION
~~(Rendered version available at https://bocoup.github.io/permissions/index.html#automation)~~ Thanks to gh-152, previews are now created automatically

The goal of this patch is to support user-agent automation and application testing for integration with the Permissions API. It's based on [a recent mailing list discussion](http://lists.w3.org/Archives/Public/public-webappsec/2017May/0001.html) and [subsequent "brainstorming"
document](https://docs.google.com/document/d/1Oe4VhgdFnZ6ID3WGyG97n_b1khvYsRcX7T4ddNcyJ9A/edit#heading=h.xws79928vxeg). There, we decided that it would be necessary to simulate user response to "pending" requests from the "request permission to use" and "prompt the user to choose" algorithms. However, the specification does not currently track these requests outside of the algorithms themselves. Automation introduces the need for two operations:

1. Retrieving pending requests
2. Request differentiation

Both of these could certainly be implemented in formal specification language, though this would involve modification of sections other than "Automation". In some ways, we are breaking new ground here, and I am reluctant to complicate this specification (or any other) with normative text that does not directly further the use case. So for this initial draft, I have erred on the side of minimalism. More specifically:

1. I have implemented request retrieval with the text: "each 'request
   permission to use' operation that is awaiting user input" and "each 'prompt
   the user to choose' operation that is awaiting user input". Is that
   sufficient?
2. I'm assuming that one the requests have been retrieved, they may be uniquely
   identified by the permission descriptor that was used to create them.  My
   understanding is that although the UA may choose to present requests to the
   user in a number of different ways (i.e. consolidating parallel requests for
   distinct Bluetooth devices), each request must still be associated with a
   single permission descriptor as specified through the JavaScript API. When
   it comes to simulating user denial, this approach conflates "use" requests
   and "choose" requests under the assumption that a given permission
   descriptor will never describe both kinds of requests simultaneously. Is
   that accurate?

Separately, it looks as though there is no restriction on the value type for options available in "prompt the user to choose." Is this intentional? For now, the proposed automation language is similarly type-neutral.

...but these are just the potential problems that I've identified. I welcome feedback of any kind, of course!

cc @shs96c @foolip


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/permissions/pull/151.html" title="Last updated on Dec 22, 2017, 2:24 AM GMT (a392308)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/151/6a0186c...bocoup:a392308.html" title="Last updated on Dec 22, 2017, 2:24 AM GMT (a392308)">Diff</a>