### PR TITLE
Add support for permissions that have an associated Feature Policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,11 +44,6 @@ spec: sensors; urlPrefix: https://w3c.github.io/sensors/#
 spec: manifest; urlPrefix: https://w3c.github.io/manifest/#
     type: dfn
         text: install; url: dfn-install
-spec: feature-policy; urlPrefix: https://wicg.github.io/feature-policy/#
-    type: dfn
-        text: policy-controlled feature
-    type: dfn
-        text: feature name
 
 </pre>
 <pre class="link-defaults">
@@ -239,16 +234,13 @@ spec: webidl
           <a>allowed in non-secure contexts</a>, then return {{"denied"}}.
         </li>
         <li>
-          If there exists a <a>policy-controlled feature</a> with a
-          <a>feature name</a> that is equal to
-          <code>|descriptor|.{{PermissionDescriptor/name}}</code> and
-          |settings| has an <a>associated `Document`</a> named <var>document</var>,
-          run the following step:
+          If there exists a [=policy-controlled feature=] identified by
+          <code>|descriptor|.{{PermissionDescriptor/name}}</code> and |settings| has an
+          <a>associated `Document`</a> named <var>document</var>, run the following step:
           <ol class="algorithm">
             <li>
               If <var>document</var> is not <a>allowed to use</a> the feature
-              with the <a>feature name</a>
-              <code>|descriptor|.{{PermissionDescriptor/name}}</code>
+              identified by <code>|descriptor|.{{PermissionDescriptor/name}}</code>
               return {{"denied"}}.
             </li>
           </ol>

--- a/index.bs
+++ b/index.bs
@@ -44,6 +44,11 @@ spec: sensors; urlPrefix: https://w3c.github.io/sensors/#
 spec: manifest; urlPrefix: https://w3c.github.io/manifest/#
     type: dfn
         text: install; url: dfn-install
+spec: feature-policy; urlPrefix: https://wicg.github.io/feature-policy/#
+    type: dfn
+        text: policy-controlled feature
+    type: dfn
+        text: feature name
 
 </pre>
 <pre class="link-defaults">
@@ -232,6 +237,21 @@ spec: webidl
           If |settings| is a <a>non-secure context</a>
           and <code>|descriptor|.{{PermissionDescriptor/name}}</code> isn't
           <a>allowed in non-secure contexts</a>, then return {{"denied"}}.
+        </li>
+        <li>
+          If there exists a <a>policy-controlled feature</a> with a
+          <a>feature name</a> that is equal to
+          <code>|descriptor|.{{PermissionDescriptor/name}}</code> and
+          |settings| has an <a>associated `Document`</a> named <var>document</var>,
+          run the following step:
+          <ol class="algorithm">
+            <li>
+              If <var>document</var> is not <a>allowed to use</a> the feature
+              with the <a>feature name</a>
+              <code>|descriptor|.{{PermissionDescriptor/name}}</code>
+              return {{"denied"}}.
+            </li>
+          </ol>
         </li>
         <li>
           If there was a previous invocation of this algorithm with the same
@@ -785,13 +805,6 @@ spec: webidl
       specified in [[GETUSERMEDIA]] and [[audio-output]]. {{"speaker"}} is
       <a>allowed in non-secure contexts</a>. {{"camera"}} and {{"microphone"}}
       MAY be <a>allowed in non-secure contexts</a>.
-    </p>
-    <p>
-      If the <a>current global object</a> has an <a>associated `Document`</a>,
-      and that {{Document}} is not <a>allowed to use</a> the feature indicated
-      by attribute name <{iframe/allowusermedia}>, then the <a>permission
-      state</a> of any descriptor with a {{PermissionDescriptor/name}} of
-      {{"camera"}} or {{"microphone"}} must be {{"denied"}}.
     </p>
     <dl>
       <dt>


### PR DESCRIPTION
This adds support for denying access to permissions which are not
allowed in the current context based on an associated Feature Policy.
The Feature Name and Default Allowlist of a policy-controlled feature
must still be declared in the owning spec. This also removes specific
support for the media feature policy which is covered by the more
general support.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/raymeskhoury/permissions/pull/163.html" title="Last updated on Sep 3, 2018, 6:55 AM GMT (e5f7e85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/163/eb267d4...raymeskhoury:e5f7e85.html" title="Last updated on Sep 3, 2018, 6:55 AM GMT (e5f7e85)">Diff</a>