### PR TITLE
Automation: simplify URI template

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -50,8 +50,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
         text: WebDriver error; url: dfn-error
         text: WebDriver error code; url: dfn-error-code
         text: extension command; url: dfn-extension-commands
-        text: extension command name; url: dfn-extension-command-name
-        text: extension command prefix; url: dfn-extension-command-prefix
+        text: extension command URI template; url: dfn-extension-command-uri-template
         text: invalid argument; url: dfn-invalid-argument
         text: local end; url: dfn-local-end
         text: remote end steps; url: dfn-remote-end-steps
@@ -1016,13 +1015,11 @@ spec: webidl
       <tbody>
         <tr>
           <th>HTTP Method</th>
-          <th><a lt="extension command prefix">Prefix</a></th>
-          <th><a lt="extension command name">Name</a></th>
+          <th><a lt="extension command URI template">URI Template</a></th>
         </tr>
         <tr>
           <td>POST</td>
           <td>/session/{session id}/permissions</td>
-          <td>set</td>
         </tr>
       </tbody>
     </table>
@@ -1088,8 +1085,8 @@ spec: webidl
     <div class="example">
       To set permission for <code>{name: {{"midi"}}, sysex: true}</code> of the
       <a>current browsing context</a> of the <a>session</a> with ID 23 to
-      "`granted`", the <a>local end</a> would POST to
-      `/session/23/permissions/set` with the body:
+      "`granted`", the <a>local end</a> would POST to `/session/23/permissions`
+      with the body:
 
       <pre class="lang-json">
       {


### PR DESCRIPTION
The WebDriver specification was recently updated to better-support
extension by web standards [1]. This change allows extension commands to
be defined without a dedicated "name". Because the Automation section
only defines a single command, the name "set" is superfluous. Remove it
in order to expose a more idiomatic HTTP API.

[1] https://github.com/w3c/webdriver/pull/1177


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jugglinmike/permissions/pull/168.html" title="Last updated on Jan 15, 2018, 7:02 PM GMT (af9e221)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/168/993ab2f...jugglinmike:af9e221.html" title="Last updated on Jan 15, 2018, 7:02 PM GMT (af9e221)">Diff</a>