### PR TITLE
Adding background fetch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -614,6 +614,7 @@ spec: webidl
       <a enum-value>"microphone"</a>,
       <a enum-value>"speaker"</a>,
       <a enum-value>"device-info"</a>,
+      <a enum-value>"background-fetch"</a>,
       <a enum-value>"background-sync"</a>,
       <a enum-value>"bluetooth"</a>,
       <a enum-value>"persistent-storage"</a>,
@@ -915,6 +916,16 @@ spec: webidl
       {{MediaDevices/devicechange}} events fire when the current browsing
       context is not in focus. The {{"device-info"}} permission MUST be revoked
       when {{MediaDeviceInfo/deviceId}}s for an origin are reset.
+    </p>
+  </section>
+  <section>
+    <h3 id="background-fetch">
+      Background Fetch
+    </h3>
+    <p>
+      The <dfn for="PermissionName" enum-value>"background-fetch"</dfn>
+      permission is the permission associated with the usage of
+      [[background-fetch]].
     </p>
   </section>
   <section>


### PR DESCRIPTION
Similar to background-sync, users will be able to deny background fetches.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jakearchibald/permissions/pull/183.html" title="Last updated on Sep 14, 2018, 8:34 AM GMT (096436e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/183/79f9c4e...jakearchibald:096436e.html" title="Last updated on Sep 14, 2018, 8:34 AM GMT (096436e)">Diff</a>