### PR TITLE
Add 'display' permission for screen-capture.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -623,6 +623,7 @@ spec: webidl
       <a enum-value>"gyroscope"</a>,
       <a enum-value>"magnetometer"</a>,
       <a enum-value>"clipboard"</a>,
+      <a enum-value>"display"</a>,
     };
   </pre>
   <p class="note">
@@ -1003,6 +1004,26 @@ spec: webidl
       permission is the permission associated with the usage of the
       asynchronous methods in the [[clipboard-apis]].
     </p>
+  </section>
+  <section>
+    <h3 id="screen-capture">
+      Screen Capture
+    </h3>
+    <p>
+      The <dfn for="PermissionName" enum-value>"display"</dfn>
+      permission is the permission associated with the usage of
+      [[screen-capture]].
+    </p>
+    <dl>
+      <dt>
+        <a>permission state constraints</a>
+      </dt>
+      <dd>
+        Valid values for this descriptor's <a>permission state</a> are
+        {{"prompt"}} and {{"denied"}}. The user agent MUST NOT ever set this
+        descriptor's <a>permission state</a> to {{"granted"}}.
+      </dd>
+    </dl>
   </section>
 </section>
 <section>


### PR DESCRIPTION
Fix for https://github.com/w3c/permissions/issues/182.

PTAL @raymeskhoury @marcoscaceres


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/permissions/pull/184.html" title="Last updated on Oct 11, 2018, 9:38 PM GMT (c5ac43a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/184/a58dae5...jan-ivar:c5ac43a.html" title="Last updated on Oct 11, 2018, 9:38 PM GMT (c5ac43a)">Diff</a>