### PR TITLE
Rename 'display' permission to 'display-capture'.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -623,7 +623,7 @@ spec: webidl
       <a enum-value>"gyroscope"</a>,
       <a enum-value>"magnetometer"</a>,
       <a enum-value>"clipboard"</a>,
-      <a enum-value>"display"</a>,
+      <a enum-value>"display-capture"</a>,
     };
   </pre>
   <p class="note">
@@ -1010,7 +1010,7 @@ spec: webidl
       Screen Capture
     </h3>
     <p>
-      The <dfn for="PermissionName" enum-value>"display"</dfn>
+      The <dfn for="PermissionName" enum-value>"display-capture"</dfn>
       permission is the permission associated with the usage of
       [[screen-capture]].
     </p>


### PR DESCRIPTION
To align with https://github.com/w3c/mediacapture-screen-share/pull/87.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/permissions/pull/188.html" title="Last updated on Dec 31, 2018, 8:19 PM UTC (b2054b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/188/a951a0e...jan-ivar:b2054b9.html" title="Last updated on Dec 31, 2018, 8:19 PM UTC (b2054b9)">Diff</a>