### PR TITLE
Direct Connection Permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1037,8 +1037,8 @@ spec: webidl
     </h3>
     <p>
       The <dfn for="PermissionName" enum-value>"direct-connection"</dfn>
-      permission is the permission associated with the usage of the <i>Direct
-      Connection API</i> of [[webrtc]].
+      permission upgrades to a less strict IP handling mode of
+      [[rtcweb-ip-handling]].
     </p>
   </section>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -892,6 +892,12 @@ spec: webidl
         <li>If <var>result</var> is {{"granted"}}, the UA MUST set the
         {{"device-info"}} permission to {{"granted"}} for this <a>realm</a>.
         </li>
+        <li>If <var>result</var> is {{"granted"}} and
+        <code>|descriptor|.{{PermissionDescriptor/name}}</code> is either
+        {{"camera"}} or {{"microphone"}}, the UA MAY set the
+        {{"direct-connection"}} permission to {{"granted"}} for this
+        <a>realm</a>.
+        </li>
         <li>The UA MAY treat <var>result</var> as <a>new information about the
         user's intent</a> with respect to the {{"device-info"}} permission for
         this <a>realm</a> and other <a>realms</a> with the <a>same origin</a>,

--- a/index.bs
+++ b/index.bs
@@ -1025,6 +1025,16 @@ spec: webidl
       </dd>
     </dl>
   </section>
+  <section>
+    <h3 id="direct-connection">
+      Direct Connection
+    </h3>
+    <p>
+      The <dfn for="PermissionName" enum-value>"direct-connection"</dfn>
+      permission is the permission associated with the usage of the <i>Direct
+      Connection API</i> of [[webrtc]].
+    </p>
+  </section>
 </section>
 <section>
   <h2 id="automation">


### PR DESCRIPTION
This adds a new permission called `direct-connection` which specifies how the IP handling mode of a WebRTC peer-to-peer connection is being upgraded.

A couple of background notes: The mechanism triggering the upgrade of the IP handling mode, piggybacked on `getUserMedia`, already exists in most browsers but it is not being reflected in the API. This change now allows to leverage the permission by other mechanisms and clarifies that `getUserMedia` may implicitly grant it.

More details on the rationale are being described in the [Direct Connection PR](https://github.com/w3c/webrtc-pc/pull/2175#issue-271288320) towards the WebRTC WG.

/cc @jan-ivar @alvestrand


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lgrahl/permissions/pull/196.html" title="Last updated on Feb 16, 2021, 11:20 PM UTC (9d2ea2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/196/ecc3821...lgrahl:9d2ea2c.html" title="Last updated on Feb 16, 2021, 11:20 PM UTC (9d2ea2c)">Diff</a>