### PR TITLE
Add nfc permission.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -624,6 +624,7 @@ spec: webidl
       <a enum-value>"magnetometer"</a>,
       <a enum-value>"clipboard"</a>,
       <a enum-value>"display-capture"</a>,
+      <a enum-value>"nfc"</a>,
     };
   </pre>
   <p class="note">
@@ -1024,6 +1025,16 @@ spec: webidl
         descriptor's <a>permission state</a> to {{"granted"}}.
       </dd>
     </dl>
+  </section>
+  <section>
+    <h3 id="nfc">
+      NFC
+    </h3>
+    <p>
+      The <dfn for="PermissionName" enum-value>"nfc"</dfn>
+      permission is the permission associated with the usage of the
+      [[web-nfc]] API.
+    </p>
   </section>
 </section>
 <section>


### PR DESCRIPTION
The [web-nfc spec]( https://w3c.github.io/web-nfc/ ) defines that UAs should [obtain permissions](https://w3c.github.io/web-nfc/#permissions-and-user-prompts) using Permissions API, but user prompts can be decided by UA policies. 

For example, Chrome team's current stand is summarized [here](https://github.com/chromium/permission.site/pull/61#issuecomment-538391691).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/riju/permissions/pull/201.html" title="Last updated on Oct 10, 2019, 1:42 PM UTC (8745b05)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/201/ecc3821...riju:8745b05.html" title="Last updated on Oct 10, 2019, 1:42 PM UTC (8745b05)">Diff</a>