### PR TITLE
Add CameraDevicePermissionDescriptor for 'camera' permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -825,6 +825,10 @@ spec: webidl
           dictionary DevicePermissionDescriptor : PermissionDescriptor {
             DOMString deviceId;
           };
+
+          dictionary CameraDevicePermissionDescriptor : DevicePermissionDescriptor {
+            boolean panTiltZoom = false;
+          };
         </pre>
         <p>
           A permission covers access to the device given in the associated
@@ -844,6 +848,10 @@ spec: webidl
           If a permission state is present for access to some, but not all,
           cameras, a query without the {{DevicePermissionDescriptor/deviceId}}
           will return {{"prompt"}}.
+        </p>
+        <p>
+          `{name: "camera", panTiltZoom: true}` is <a>stronger than</a>
+          `{name: "camera", panTiltZoom: false}`.
         </p>
         <p>
           Note that a "granted" permission is no guarantee that getUserMedia


### PR DESCRIPTION
This allows to differentiate between normal camera permissions and
pan-tilt-zoom camera permissions.

In https://github.com/w3ctag/design-reviews/issues/358, TAG wants that there are distinct prompt for camera and pan/tilt/zoom. This CL adds a CameraDevicePermissionDescriptor dictionary so that the normal camera permission can be requested using {name: "camera", panTiltZoom: false} while the pan/tilt/zoom camera permission can be requested using {name: "camera", panTiltZoom: true}.

The CameraDevicePermissionDescriptor can then be referenced by media capture specifications.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eehakkin/intel-w3c-permissions/pull/204.html" title="Last updated on Mar 20, 2020, 1:34 PM UTC (daadf87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/204/9f076df...eehakkin:daadf87.html" title="Last updated on Mar 20, 2020, 1:34 PM UTC (daadf87)">Diff</a>