### PR TITLE
Remove webdriver-spec.html from WebDriver URLs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,7 +44,7 @@ spec: sensors; urlPrefix: https://w3c.github.io/sensors/#
 spec: manifest; urlPrefix: https://w3c.github.io/manifest/#
     type: dfn
         text: install; url: dfn-install
-spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#
     type: dfn
         text: current browsing context; url: dfn-current-browsing-context
         text: WebDriver error; url: dfn-error


### PR DESCRIPTION
It redirects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/permissions/pull/208.html" title="Last updated on Jun 2, 2020, 10:23 AM UTC (97d643e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/208/9675ebf...foolip:97d643e.html" title="Last updated on Jun 2, 2020, 10:23 AM UTC (97d643e)">Diff</a>