### PR TITLE
Update clipboard permissions as per Clipboard Specification.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -622,7 +622,8 @@ spec: webidl
       <a enum-value>"accelerometer"</a>,
       <a enum-value>"gyroscope"</a>,
       <a enum-value>"magnetometer"</a>,
-      <a enum-value>"clipboard"</a>,
+      <a enum-value>"clipboard-read"</a>,
+      <a enum-value>"clipboard-write"</a>,
       <a enum-value>"display-capture"</a>,
       <a enum-value>"nfc"</a>,
     };
@@ -1005,13 +1006,23 @@ spec: webidl
     </p>
   </section>
   <section>
-    <h3 id="clipboard">
-      Clipboard
+    <h3 id="clipboard-read">
+      Clipboard Read
     </h3>
     <p>
-      The <dfn for="PermissionName" enum-value>"clipboard"</dfn>
+      The <dfn for="PermissionName" enum-value>"clipboard-read"</dfn>
       permission is the permission associated with the usage of the
-      asynchronous methods in the [[clipboard-apis]].
+      asynchronous read methods in the [[clipboard-apis]].
+    </p>
+  </section>
+  <section>
+    <h3 id="clipboard-write">
+      Clipboard Write
+    </h3>
+    <p>
+      The <dfn for="PermissionName" enum-value>"clipboard-write"</dfn>
+      permission is the permission associated with the usage of the
+      asynchronous write methods in the [[clipboard-apis]].
     </p>
   </section>
   <section>


### PR DESCRIPTION
The [Clipboard API Spec](https://www.w3.org/TR/clipboard-apis/#clipboard-permissions) has had separate `clipboard-read` and `clipboard-write` permissions for a while now, so let's update this spec to mention this. This was mentioned in https://github.com/w3c/permissions/issues/175 as well.

This is my first specification change attempt, so please let me know if there's anything I'm missing. bikeshed spec had no errors when generating this change though.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dway123/permissions/pull/209.html" title="Last updated on Jun 2, 2020, 11:13 PM UTC (0d78d2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/209/9675ebf...dway123:0d78d2f.html" title="Last updated on Jun 2, 2020, 11:13 PM UTC (0d78d2f)">Diff</a>