### PR TITLE
Noexport the "Set Permission" dfn to fix a Bikeshed warning.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1090,7 +1090,7 @@ spec: webidl
         </tr>
       </tbody>
     </table>
-    <p>The <dfn export>Set Permission</dfn> <a>extension command</a> simulates user
+    <p>The <dfn noexport>Set Permission</dfn> <a>extension command</a> simulates user
     modification of a {{PermissionDescriptor}}'s <a>permission state</a>.</p>
     <p>The <a>remote end steps</a> are:</p>
     <ol>

--- a/index.bs
+++ b/index.bs
@@ -1090,7 +1090,7 @@ spec: webidl
         </tr>
       </tbody>
     </table>
-    <p>The <dfn>Set Permission</dfn> <a>extension command</a> simulates user
+    <p>The <dfn export>Set Permission</dfn> <a>extension command</a> simulates user
     modification of a {{PermissionDescriptor}}'s <a>permission state</a>.</p>
     <p>The <a>remote end steps</a> are:</p>
     <ol>


### PR DESCRIPTION
We can `export`, explicitly `noexport`, or remove the `<dfn>`, and I'm not certain which is best. WebDriver itself gets away without making an explicit choice because it has a local use of every endpoint at https://w3c.github.io/webdriver/#endpoints. (and maybe because Respec doesn't have this warning?) I don't see a reason another specification would depend on this, so `noexport` should be fine, but because it's a public API used by tests, `export` seems semantically right, so I went with `export`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/permissions/pull/216.html" title="Last updated on Jul 23, 2020, 10:34 PM UTC (3db5fbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/216/e38762b...jyasskin:3db5fbd.html" title="Last updated on Jul 23, 2020, 10:34 PM UTC (3db5fbd)">Diff</a>