### PR TITLE
Rename "speaker" to "speaker-selection" + media devices are secure context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -613,7 +613,7 @@ spec: webidl
       <a enum-value>"midi"</a>,
       <a enum-value>"camera"</a>,
       <a enum-value>"microphone"</a>,
-      <a enum-value>"speaker"</a>,
+      <a enum-value>"speaker-selection"</a>,
       <a enum-value>"device-info"</a>,
       <a enum-value>"background-fetch"</a>,
       <a enum-value>"background-sync"</a>,
@@ -812,11 +812,9 @@ spec: webidl
     </h3>
     <p dfn-for="PermissionName" dfn-type="enum-value">
       The <dfn>"camera"</dfn>, <dfn>"microphone"</dfn> , and
-      <dfn>"speaker"</dfn>
+      <dfn>"speaker-selection"</dfn>
       permissions are associated with permission to use media devices as
-      specified in [[GETUSERMEDIA]] and [[audio-output]]. {{"speaker"}} is
-      <a>allowed in non-secure contexts</a>. {{"camera"}} and {{"microphone"}}
-      MAY be <a>allowed in non-secure contexts</a>.
+      specified in [[GETUSERMEDIA]] and [[audio-output]].
     </p>
     <dl>
       <dt>


### PR DESCRIPTION
The `"speaker"` permission is used by the new [selectAudioOutput](https://w3c.github.io/mediacapture-output/#dom-mediadevices-selectaudiooutput) API, but is being renamed in https://github.com/w3c/mediacapture-output/pull/96 for consistency with the reintroduced permissions policy of the same name. https://github.com/w3c/webappsec-permissions-policy/pull/398

The old name had folks thinking an iframe without `allow="speaker"` would be silent. The new name clarifies the powerful feature in question is instead the ability to request and output to non-default audio output devices.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/permissions/pull/218.html" title="Last updated on Jul 22, 2020, 12:47 AM UTC (ea5bede)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/218/96646df...jan-ivar:ea5bede.html" title="Last updated on Jul 22, 2020, 12:47 AM UTC (ea5bede)">Diff</a>