### PR TITLE
Auto-fetch the previous version link.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,8 +10,7 @@ Group: webappsec
 Editor: Mounir Lamouri, w3cid 45389, Google Inc. https://google.com/
 Editor: Marcos Cáceres, w3cid 39125, Mozilla https://mozilla.com/
 Editor: Jeffrey Yasskin, w3cid 72192, Google Inc. https://google.com/
-Previous Version: https://www.w3.org/TR/2017/WD-permissions-20170925/
-Previous Version: https://www.w3.org/TR/2015/WD-permissions-20150407/
+Previous Version: from biblio permissions
 
 Abstract: The <cite>Permissions Standard</cite> defines common infrastructure for other specifications that need to interact with browser permissions. It also defines an API to allow web applications to query and request changes to the status of a given permission.
 Mailing List: public-webappsec@w3.org


### PR DESCRIPTION
This will allow echidna to keep the spec updated. See #215.

THIS IS CURRENTLY BROKEN: it links to `permissions-policy-1` instead of `permissions`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/permissions/pull/219.html" title="Last updated on Feb 16, 2021, 11:20 PM UTC (520ee29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/219/96646df...jyasskin:520ee29.html" title="Last updated on Feb 16, 2021, 11:20 PM UTC (520ee29)">Diff</a>