### PR TITLE
Use media device permission revocation algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -890,7 +890,7 @@ spec:infra; type:dfn; text:list
       </dt>
       <dd>
         This is the result of calling the
-        <a>media device permission revocation algorithm</a> passing {{name}}
+        [=device permission revocation algorithm=] passing {{name}}
         and {{deviceId}} as arguments. If the descriptor does not have a
         {{deviceId}}, then <code>undefined</code> is passed in place of
         {{deviceId}}.

--- a/index.bs
+++ b/index.bs
@@ -39,6 +39,8 @@ spec: mediacapture-main; urlPrefix: https://w3c.github.io/mediacapture-main/#
         for: MediaDevices; text: getUserMedia(); url: dom-mediadevices-getusermedia
     type: event
         for: MediaDevices; text: devicechange
+    type: dfn
+        text: media device permission revocation algorithm; url: dfn-device-permission-revocation-algorithm
 spec: sensors; urlPrefix: https://w3c.github.io/sensors/#
     type: dfn
         text: generic sensor permission revocation algorithm; url: generic-sensor-permission-revocation-algorithm
@@ -889,10 +891,11 @@ spec:infra; type:dfn; text:list
         <a>permission revocation algorithm</a>
       </dt>
       <dd>
-        When permission for a device is revoked, the UA MUST run the
-        algorithm to stop the track for any other reason than the stop()
-        method being invoked for each MediaStreamTrack sourced from that
-        device. <!--TODO make a link target in the spec -->
+        This is the result of calling the
+        <a>media device permission revocation algorithm</a> passing {{name}}
+        and {{deviceId}} as arguments. If the descriptor does not have a
+        {{deviceId}}, then <code>undefined</code> is passed in place of
+        {{deviceId}}.
       </dd>
     </dl>
     <p>

--- a/index.bs
+++ b/index.bs
@@ -39,8 +39,6 @@ spec: mediacapture-main; urlPrefix: https://w3c.github.io/mediacapture-main/#
         for: MediaDevices; text: getUserMedia(); url: dom-mediadevices-getusermedia
     type: event
         for: MediaDevices; text: devicechange
-    type: dfn
-        text: media device permission revocation algorithm; url: dfn-device-permission-revocation-algorithm
 spec: sensors; urlPrefix: https://w3c.github.io/sensors/#
     type: dfn
         text: generic sensor permission revocation algorithm; url: generic-sensor-permission-revocation-algorithm


### PR DESCRIPTION
Counterpart to https://github.com/w3c/mediacapture-main/pull/745 based on https://github.com/w3c/permissions/issues/223#issuecomment-681327793.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/permissions/pull/225.html" title="Last updated on Jun 3, 2021, 1:22 AM UTC (f005cb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/225/9cbf73c...jan-ivar:f005cb1.html" title="Last updated on Jun 3, 2021, 1:22 AM UTC (f005cb1)">Diff</a>