### PR TITLE
Expose PermissionName as IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -579,30 +579,28 @@ spec:infra; type:dfn; text:list
   <h2 id="permission-registry">
     Permission Registry
   </h2>
-  <!-- IDL blocks can't link outside the current spec, but these enum-values are
-       supposed to be defined in other specs. -->
-  <pre highlight='idl' link-for="PermissionName">
-    enum <dfn enum>PermissionName</dfn> {
-      <a enum-value>"geolocation"</a>,
-      <a enum-value>"notifications"</a>,
-      <a enum-value>"push"</a>,
-      <a enum-value>"midi"</a>,
-      <a enum-value>"camera"</a>,
-      <a enum-value>"microphone"</a>,
-      <a enum-value>"speaker-selection"</a>,
-      <a enum-value>"device-info"</a>,
-      <a enum-value>"background-fetch"</a>,
-      <a enum-value>"background-sync"</a>,
-      <a enum-value>"bluetooth"</a>,
-      <a enum-value>"persistent-storage"</a>,
-      <a enum-value>"ambient-light-sensor"</a>,
-      <a enum-value>"accelerometer"</a>,
-      <a enum-value>"gyroscope"</a>,
-      <a enum-value>"magnetometer"</a>,
-      <a enum-value>"clipboard-read"</a>,
-      <a enum-value>"clipboard-write"</a>,
-      <a enum-value>"display-capture"</a>,
-      <a enum-value>"nfc"</a>,
+  <pre class='idl'>
+    enum PermissionName {
+      "geolocation",
+      "notifications",
+      "push",
+      "midi",
+      "camera",
+      "microphone",
+      "speaker-selection",
+      "device-info",
+      "background-fetch",
+      "background-sync",
+      "bluetooth",
+      "persistent-storage",
+      "ambient-light-sensor",
+      "accelerometer",
+      "gyroscope",
+      "magnetometer",
+      "clipboard-read",
+      "clipboard-write",
+      "display-capture",
+      "nfc",
     };
   </pre>
   <p class="note">
@@ -922,6 +920,26 @@ spec:infra; type:dfn; text:list
       The <dfn for="PermissionName" enum-value>"background-sync"</dfn>
       permission is the permission associated with the usage of
       [[web-background-sync]].
+    </p>
+  </section>
+  <section>
+    <h3 id="bluetooth">
+      Bluetooth
+    </h3>
+    <p>
+      The <dfn for="PermissionName" enum-value>"bluetooth"</dfn>
+      permission is the permission associated with the usage of
+      [[web-bluetooth]].
+    </p>
+  </section>
+  <section>
+    <h3 id="persistent-storage">
+      Persistent Storage
+    </h3>
+    <p>
+      The <dfn for="PermissionName" enum-value>"persistent-storage"</dfn>
+      permission is the permission associated with the usage of
+      [[storage]].
     </p>
   </section>
   <section>

--- a/index.bs
+++ b/index.bs
@@ -928,8 +928,8 @@ spec:infra; type:dfn; text:list
     </h3>
     <p>
       The <dfn for="PermissionName" enum-value>"bluetooth"</dfn>
-      permission is the permission associated with the usage of
-      [[web-bluetooth]].
+      permission ([[web-bluetooth#permission-api-integration]]) controls usage
+      of [[web-bluetooth]].
     </p>
   </section>
   <section>
@@ -938,8 +938,9 @@ spec:infra; type:dfn; text:list
     </h3>
     <p>
       The <dfn for="PermissionName" enum-value>"persistent-storage"</dfn>
-      permission is the permission associated with the usage of
-      [[storage]].
+      permission ([[storage#persistence]]) is the permission associated with the
+      usage of the `"persistent"` storage bucket <a spec="storage" for="local
+      storage bucket">mode</a>.
     </p>
   </section>
   <section>


### PR DESCRIPTION
#156 hided PermissionName to fix linking issues but doing so prevents IDL crawlers to collect the type properly. This patch reverts it and instead makes things consistent with other enum values.

See also https://github.com/w3c/webref/issues/47


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/permissions/pull/229.html" title="Last updated on Feb 17, 2021, 12:33 AM UTC (cd7f1ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/229/9cbf73c...saschanaz:cd7f1ad.html" title="Last updated on Feb 17, 2021, 12:33 AM UTC (cd7f1ad)">Diff</a>