### PR TITLE
Remove Permission Registry provisional note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -603,13 +603,6 @@ spec:infra; type:dfn; text:list
       "nfc",
     };
   </pre>
-  <p class="note">
-  The enumeration values {{"accelerometer"}}, {{"gyroscope"}} and
-  {{"magnetometer"}} are considered provisional and are subject to change
-  based on feedback from early implementations. See
-  <a href="https://github.com/w3c/sensors/issues/22">w3c/sensors#22</a> issue
-  for more information.
-  </p>
   <p>
     Each enumeration value in the {{PermissionName}} enum identifies a
     <a>powerful feature</a>. Each <a>powerful feature</a> has the following


### PR DESCRIPTION
Also WebKit implements these permissions:
https://bugs.webkit.org/show_bug.cgi?id=221399


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anssiko/permissions/pull/232.html" title="Last updated on Mar 25, 2021, 3:03 PM UTC (2de2a13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/232/388ee1c...anssiko:2de2a13.html" title="Last updated on Mar 25, 2021, 3:03 PM UTC (2de2a13)">Diff</a>