### PR TITLE
Add name attribute to PermissionStatus

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -438,6 +438,7 @@ spec:webidl; type:interface; text:Promise
     [Exposed=(Window,Worker)]
     interface PermissionStatus : EventTarget {
       readonly attribute PermissionState state;
+      readonly attribute PermissionName name;
       attribute EventHandler onchange;
     };
   </pre>
@@ -452,7 +453,11 @@ spec:webidl; type:interface; text:Promise
     |permissionDesc|, return a new instance of the <a>permission result
     type</a> for the feature named by <code>|permissionDesc|.{{PermissionDescriptor/name}}</code>,
     with the {{PermissionStatus/[[query]]}} internal slot initialized to
-    |permissionDesc|.
+    |permissionDesc|, and {{PermissionStatus/name}} initialized to |permissionDesc|.{{PermissionDescriptor/name}}.
+  </p>
+  <p>
+    The <dfn for="PermissionStatus" attribute>name</dfn>
+    attribute returns the value it was initialized to.
   </p>
   <p>
     The <dfn for="PermissionStatus" attribute>state</dfn>


### PR DESCRIPTION
closes #237

Avoids having to rely on array order to know what a particular permission status belongs to.  

The following tasks have been completed:

 * [ ] Modified Web platform tests (link)

Implementation commitment:

 * [ ] WebKit  - doesn't implement the API
 * [ ] [Blink](https://bugs.chromium.org/p/chromium/issues/detail?id=1236856) 
 * [ ] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1718021)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/248.html" title="Last updated on Aug 5, 2021, 4:20 AM UTC (5960935)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/248/f5d8cac...5960935.html" title="Last updated on Aug 5, 2021, 4:20 AM UTC (5960935)">Diff</a>