### PR TITLE
Handle not fully active documents when querying Permissions API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -197,7 +197,7 @@ spec:webidl; type:interface; text:Promise
         A |descriptor|'s <dfn export local-lt="state">permission state</dfn> for
         an optional <a>environment settings object</a> |settings| is
         the result of the following algorithm, which returns one of
-        {{PermissionState/"granted"}}, {{PermissionState/"prompt"}}, or {{PermissionState/"denied"}}:
+        the {{PermissionState}} enum values or failure:
       </p>
       <ol class="algorithm">
         <li>
@@ -213,6 +213,9 @@ spec:webidl; type:interface; text:Promise
           <code>|descriptor|.{{PermissionDescriptor/name}}</code> and |settings| has an
           <a>associated `Document`</a> named <var>document</var>, run the following step:
           <ol class="algorithm">
+            <li>
+              If |document| is not [=Document/fully active=], return failure.
+            </li>
             <li>
               If <var>document</var> is not <a>allowed to use</a> the feature
               identified by <code>|descriptor|.{{PermissionDescriptor/name}}</code>
@@ -509,7 +512,6 @@ spec:webidl; type:interface; text:Promise
       Promise&lt;PermissionStatus&gt; query(object permissionDesc);
     };
   </pre>
-<<<<<<< HEAD
   <section>
     <h3 id="query-method">`query()` method</h3>
     <p>
@@ -519,6 +521,15 @@ spec:webidl; type:interface; text:Promise
       <var>permissionDesc</var>:
     </p>
     <ol>
+      <li>
+        If [=this=] [=relevant global object=] is a {{Window}} object, then:
+        <ol>
+          <li>If the [=current settings object's=] <a>associated `Document`</a> is not
+          [=Document/fully active=], return [=a promise rejected with=] a
+          {{"InvalidStateError"}} {{DOMException}}.
+          </li>
+        </ol>
+      </li>
       <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to
       an IDL value</a> of type {{PermissionDescriptor}}. If this throws an
       exception, return <a>a promise rejected with</a> that exception and abort
@@ -551,50 +562,6 @@ spec:webidl; type:interface; text:Promise
       found in the <a href='#examples'>Examples section</a>.
     </div>
   </section>
-=======
-  <p>
-    When the <dfn for='Permissions' method>query(permissionDesc)</dfn> method is
-    invoked, the <a>user agent</a> MUST run the following <dfn export>query a
-    permission</dfn> algorithm, passing the parameter
-    <var>permissionDesc</var>:
-  </p>
-  <ol>
-    <li>If the [=current settings object=]'s [=associated Document=] is not
-    [=Document/fully active=], return [=a promise rejected with=] a
-    "InvalidStateError" {{DOMException}}.
-    </li>
-    <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to
-    an IDL value</a> of type {{PermissionDescriptor}}. If this throws an
-    exception, return <a>a promise rejected with</a> that exception and abort
-    these steps.
-    </li>
-    <li>Let |typedDescriptor| be the object |permissionDesc| refers to,
-    <a>converted to an IDL value</a> of
-    <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s <a>permission
-    descriptor type</a>. If this throws an exception, return <a>a promise
-    rejected with</a> that exception and abort these steps.
-    </li>
-    <li>Let <var>promise</var> be a newly-created {{Promise}}.
-    </li>
-    <li>Return <var>promise</var> and continue the following steps
-    asynchronously.
-    </li>
-    <li>Run the steps to <a>create a PermissionStatus</a> for |typedDescriptor|,
-    and let <var>status</var> be the result.
-    </li>
-    <li>
-      Run <code>|status|@{{PermissionStatus/[[query]]}}.{{PermissionDescriptor/name}}</code>'s <a>permission query
-      algorithm</a>, passing <code>|status|@{{PermissionStatus/[[query]]}}</code> and |status|.
-    </li>
-    <li>Resolve <var>promise</var> with <var>status</var>.
-    </li>
-  </ol>
-  <div class='note'>
-    If a developer wants to check multiple permissions at once, the editors
-    recommend the use of <code>{{Promise}}.all()</code>. An example can be
-    found in the <a href='#examples'>Examples section</a>.
-  </div>
->>>>>>> beadff4 (Handle not fully active documents when querying Permissions API)
 </section>
 <section>
   <h2 id="common-permission-algorithms">

--- a/index.bs
+++ b/index.bs
@@ -580,10 +580,6 @@ spec:webidl; type:interface; text:Promise
       Run <code>|status|@{{PermissionStatus/[[query]]}}.{{PermissionDescriptor/name}}</code>'s <a>permission query
       algorithm</a>, passing <code>|status|@{{PermissionStatus/[[query]]}}</code> and |status|.
     </li>
-    <li>
-      If |doc| is not longer [=Document/fully active=] when this step is reached,
-      set |status|.{{PermissionStatus/state}} to {{PermissionState/"denied"}}.
-    </li>
     <li>Resolve <var>promise</var> with <var>status</var>.
     </li>
   </ol>

--- a/index.bs
+++ b/index.bs
@@ -553,9 +553,9 @@ spec:webidl; type:interface; text:Promise
     <var>permissionDesc</var>:
   </p>
   <ol>
-    <li>Let |doc| be the [=current settings object=]'s [=associated Document=].</li>
-    <li>If |doc| is not [=Document/fully active=], return [=a promise rejected with=]
-    a "InvalidStateError" {{DOMException}}.
+    <li>If the [=current settings object=]'s [=associated Document=] is not
+    [=Document/fully active=], return [=a promise rejected with=] a
+    "InvalidStateError" {{DOMException}}.
     </li>
     <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to
     an IDL value</a> of type {{PermissionDescriptor}}. If this throws an

--- a/index.bs
+++ b/index.bs
@@ -465,6 +465,12 @@ spec:webidl; type:interface; text:Promise
   </p>
   <ol>
     <li>
+      Let |document| this |status|'s [=relevant global object=]'s [=associated Document=].
+    <li>
+    <li>
+      If |document| is null or |document| is not [=Document/fully active=], terminate this algorithm.
+    </li>
+    <li>
       Run <code><var>status</var>@{{PermissionStatus/[[query]]}}.{{PermissionDescriptor/name}}</code>'s <a>permission
       query algorithm</a>, passing <code><var>status</var>@{{PermissionStatus/[[query]]}}</code>
       and <var>status</var>.

--- a/index.bs
+++ b/index.bs
@@ -503,6 +503,7 @@ spec:webidl; type:interface; text:Promise
       Promise&lt;PermissionStatus&gt; query(object permissionDesc);
     };
   </pre>
+<<<<<<< HEAD
   <section>
     <h3 id="query-method">`query()` method</h3>
     <p>
@@ -544,6 +545,54 @@ spec:webidl; type:interface; text:Promise
       found in the <a href='#examples'>Examples section</a>.
     </div>
   </section>
+=======
+  <p>
+    When the <dfn for='Permissions' method>query(permissionDesc)</dfn> method is
+    invoked, the <a>user agent</a> MUST run the following <dfn export>query a
+    permission</dfn> algorithm, passing the parameter
+    <var>permissionDesc</var>:
+  </p>
+  <ol>
+    <li>Let |doc| be the [=current settings object=]'s [=associated Document=].</li>
+    <li>If |doc| is not [=Document/fully active=], return [=a promise rejected with=]
+    a "InvalidStateError" {{DOMException}}.
+    </li>
+    <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to
+    an IDL value</a> of type {{PermissionDescriptor}}. If this throws an
+    exception, return <a>a promise rejected with</a> that exception and abort
+    these steps.
+    </li>
+    <li>Let |typedDescriptor| be the object |permissionDesc| refers to,
+    <a>converted to an IDL value</a> of
+    <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s <a>permission
+    descriptor type</a>. If this throws an exception, return <a>a promise
+    rejected with</a> that exception and abort these steps.
+    </li>
+    <li>Let <var>promise</var> be a newly-created {{Promise}}.
+    </li>
+    <li>Return <var>promise</var> and continue the following steps
+    asynchronously.
+    </li>
+    <li>Run the steps to <a>create a PermissionStatus</a> for |typedDescriptor|,
+    and let <var>status</var> be the result.
+    </li>
+    <li>
+      Run <code>|status|@{{PermissionStatus/[[query]]}}.{{PermissionDescriptor/name}}</code>'s <a>permission query
+      algorithm</a>, passing <code>|status|@{{PermissionStatus/[[query]]}}</code> and |status|.
+    </li>
+    <li>
+      If |doc| is not longer [=Document/fully active=] when this step is reached,
+      set |status|.{{PermissionStatus/state}} to {{PermissionState/"denied"}}.
+    </li>
+    <li>Resolve <var>promise</var> with <var>status</var>.
+    </li>
+  </ol>
+  <div class='note'>
+    If a developer wants to check multiple permissions at once, the editors
+    recommend the use of <code>{{Promise}}.all()</code>. An example can be
+    found in the <a href='#examples'>Examples section</a>.
+  </div>
+>>>>>>> beadff4 (Handle not fully active documents when querying Permissions API)
 </section>
 <section>
   <h2 id="common-permission-algorithms">


### PR DESCRIPTION
closes #162 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link)

Implementation commitment:

 * [ ] WebKit (link to issue)
 * [ ] [Blink]( https://bugs.chromium.org/p/chromium/issues/detail?id=1238709)
 * [ ] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1718598) + [patch](https://phabricator.services.mozilla.com/D118932)

CC @johannhof


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/249.html" title="Last updated on Aug 20, 2021, 6:30 AM UTC (613b424)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/249/da86e19...613b424.html" title="Last updated on Aug 20, 2021, 6:30 AM UTC (613b424)">Diff</a>