### PR TITLE
Remove 'speaker-selection' enum value, as it's not implemented?

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -584,7 +584,6 @@ spec:webidl; type:interface; text:Promise
       "persistent-storage",
       "push",
       "screen-wake-lock",
-      "speaker-selection",
     };
   </pre>
   <p>
@@ -772,10 +771,9 @@ spec:webidl; type:interface; text:Promise
       Media Devices
     </h3>
     <p dfn-for="PermissionName" dfn-type="enum-value">
-      The <dfn for="PermissionName" enum-value>"camera"</dfn>, <dfn for="PermissionName" enum-value>"microphone"</dfn> , and
-      <dfn for="PermissionName" enum-value>"speaker-selection"</dfn>
+      The <dfn for="PermissionName" enum-value>"camera"</dfn>, <dfn for="PermissionName" enum-value>"microphone"</dfn>
       permissions are associated with permission to use media devices as
-      specified in [[GETUSERMEDIA]] and [[audio-output]].
+      specified in [[GETUSERMEDIA]].
     </p>
     <dl>
       <dt>


### PR DESCRIPTION
The following tasks have been completed:

 * [X] Modified Web platform tests - automatically tested on merge.

Implementation commitment:

 * ❌ WebKit 
 * ❌ Blink 
 * ❌ Gecko

Doesn't seems to be implemented by anyone at this point.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/257.html" title="Last updated on Jul 28, 2021, 7:33 AM UTC (be00c28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/257/3af5370...be00c28.html" title="Last updated on Jul 28, 2021, 7:33 AM UTC (be00c28)">Diff</a>