### PR TITLE
Editorial: mark various permissions "at risk"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,8 +18,26 @@ Assume Explicit For: true
 Prepare For TR: true
 
 Abstract: The <cite>Permissions</cite> specification defines common infrastructure for other specifications that need to interact with browser permissions. It also defines an API to allow web applications to query and be notified of changes to the status of a given permission.
+
+At Risk: The {{PermissionName/"accelerometer"}} permission.
+At Risk: The {{PermissionName/"ambient-light-sensor"}} permission.
+At Risk: The {{PermissionName/"background-fetch"}} permission.
+At Risk: The {{PermissionName/"background-sync"}} permission.
+At Risk: The {{PermissionName/"bluetooth"}} permission.
+At Risk: The {{PermissionName/"camera"}} permission.
+At Risk: The {{PermissionName/"display-capture"}} permission.
+At Risk: The {{PermissionName/"gyroscope"}} permission.
+At Risk: The {{PermissionName/"magnetometer"}} permission.
+At Risk: The {{PermissionName/"microphone"}} permission.
+At Risk: The {{PermissionName/"midi"}} permission.
+At Risk: The {{PermissionName/"nfc"}} permission.
+At Risk: The {{PermissionName/"screen-wake-lock"}} permission.
+At Risk: The {{PermissionName/"speaker-selection"}} permission.
 </pre>
 <pre class="anchors">
+spec: W3C-Process; https://www.w3.org/Consortium/Process/#
+    type: dfn
+        text: at risk; url: at-risk
 spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
     type: dfn
         text: Realm; url: sec-code-realms
@@ -740,6 +758,10 @@ spec:webidl; type:interface; text:Promise
       permission is the permission associated with the usage of
       [[webmidi]]. {{PermissionName/"midi"}} is <a>allowed in non-secure contexts</a>.
     </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      is [=at risk=].
+    </p>
     <dl>
       <dt>
         <a>permission descriptor type</a>
@@ -766,6 +788,10 @@ spec:webidl; type:interface; text:Promise
       permission is the permission associated with the usage of the
       [[screen-wake-lock]] API. It is a <a>boolean feature</a>.
     </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
   </section>
   <section>
     <h3 id="media-devices">
@@ -776,6 +802,10 @@ spec:webidl; type:interface; text:Promise
       <dfn for="PermissionName" enum-value>"speaker-selection"</dfn>
       permissions are associated with permission to use media devices as
       specified in [[GETUSERMEDIA]] and [[audio-output]].
+    </p>
+    <p class="issue">
+      These permissions only have a single implementation, and therefore, as per the W3C Process,
+      are [=at risk=].
     </p>
     <dl>
       <dt>
@@ -883,6 +913,10 @@ spec:webidl; type:interface; text:Promise
       permission is the permission associated with the usage of
       [[background-fetch]].
     </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
   </section>
   <section>
     <h3 id="background-sync">
@@ -893,6 +927,10 @@ spec:webidl; type:interface; text:Promise
       permission is the permission associated with the usage of
       [[web-background-sync]].
     </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
   </section>
   <section>
     <h3 id="bluetooth">
@@ -902,6 +940,10 @@ spec:webidl; type:interface; text:Promise
       The <dfn for="PermissionName" enum-value>"bluetooth"</dfn>
       permission ([[web-bluetooth#permission-api-integration]]) controls usage
       of [[web-bluetooth]].
+    </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
     </p>
   </section>
   <section>
@@ -923,7 +965,12 @@ spec:webidl; type:interface; text:Promise
       The <dfn for="PermissionName" enum-value>"ambient-light-sensor"</dfn>
       permission is the permission associated with the usage of the
       [[ambient-light]] API.
-
+    </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
+    <p>
       Its <a>permission revocation algorithm</a> is the result of calling
       <a>generic sensor permission revocation algorithm</a>
       passing it {{PermissionName/"ambient-light-sensor"}} as argument.
@@ -937,7 +984,12 @@ spec:webidl; type:interface; text:Promise
       The <dfn for="PermissionName" enum-value>"accelerometer"</dfn>
       permission is the permission associated with the usage of the
       [[accelerometer]] API.
-
+    </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
+    <p>
       Its <a>permission revocation algorithm</a> is the result of calling
       <a>generic sensor permission revocation algorithm</a>
       passing it {{PermissionName/"accelerometer"}} as argument.
@@ -951,7 +1003,12 @@ spec:webidl; type:interface; text:Promise
       The <dfn for="PermissionName" enum-value>"gyroscope"</dfn>
       permission is the permission associated with the usage of the
       [[gyroscope]] API.
-
+    </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
+    <p>
       Its <a>permission revocation algorithm</a> is the result of calling
       <a>generic sensor permission revocation algorithm</a>
       passing it {{PermissionName/"gyroscope"}} as argument.
@@ -965,7 +1022,12 @@ spec:webidl; type:interface; text:Promise
       The <dfn for="PermissionName" enum-value>"magnetometer"</dfn>
       permission is the permission associated with the usage of the
       [[magnetometer]] API.
-
+    </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
+    <p>
       Its <a>permission revocation algorithm</a> is the result of calling
       <a>generic sensor permission revocation algorithm</a>
       passing it {{PermissionName/"magnetometer"}} as argument.
@@ -979,6 +1041,10 @@ spec:webidl; type:interface; text:Promise
       The <dfn for="PermissionName" enum-value>"display-capture"</dfn>
       permission is the permission associated with the usage of
       [[screen-capture]].
+    </p>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
     </p>
     <dl>
       <dt>
@@ -995,6 +1061,10 @@ spec:webidl; type:interface; text:Promise
     <h3 id="nfc">
       NFC
     </h3>
+    <p class="issue">
+      This permission only has a single implementation, and therefore, as per the W3C Process,
+      it is [=at risk=].
+    </p>
     <p>
       The <dfn for="PermissionName" enum-value>"nfc"</dfn>
       permission is the permission associated with the usage of the


### PR DESCRIPTION
Marked all single engine things "at risk".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/259.html" title="Last updated on Jul 28, 2021, 9:07 AM UTC (b81c73e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/259/3af5370...b81c73e.html" title="Last updated on Jul 28, 2021, 9:07 AM UTC (b81c73e)">Diff</a>