### PR TITLE
Editorial: Relationship to the Permissions Policy specification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -561,6 +561,53 @@ spec:webidl; type:interface; text:Promise
     </li>
   </ol>
 </section>
+<section class="non-normative">
+  <h2 id="relationship-to-permissions-policy">
+    Relationship to the Permissions Policy specification
+  </h2>
+  <p>
+    Although technically this specification and the Permissions Policy
+    specification ([[Permissions-Policy]]) deal with "permissions", each
+    specification serves a distinct purpose in the platform. Nevertheless, the
+    two specifications do explicity overlap.
+  </p>
+  <p>
+    On the one hand, this specification exclusively concerns itself with
+    [=powerful features=] whose access is managed through a user-agent mediated
+    permissions UI (i.e., permissions where the user gives express consent
+    before that feature can be used, and where the user retains the ability to
+    deny that permission at any time for any reason). These powerful features
+    are explicitly identified by this specification's {{PermissionName}} enum.
+  </p>
+  <p>
+    On the other hand, the Permissions Policy specification allows developers to
+    selectively enable and disable [=powerful features=] through a
+    "[=permissions policy=]" (be it a HTTP header or a the <{iframe/allow}>
+    attribute). The APIs and features in scope for the Permissions Policy
+    specification go beyond those identified in this specification's
+    {{PermissionName}} enum (e.g., "sync-xhr" and "gamepad"). In that sense, the
+    Permissions Policy subsumes this specification in that Permissions Policy
+    governs wether a feature is available at all, independently of this
+    specification.
+  </p>
+  <p>
+    A powerful feature that has been disabled by the Permissions Policy
+    specification always has its permission state reflected as "denied" by this
+    specification. This occurs because reading the current permission state
+    relies on [[HTML]]'s "[=allowed to use=]" check, which itself calls into the
+    Permissions Policy specification. Important to note here is the sharing of
+    permission names across both specifications. Where this specifications has
+    the {{PermissionName}} enum, the Permissions Policy specification relies on
+    other specifications defining the names of the permissions (e.g., the
+    permission "gamepad" is defined in [[Gamepad]], and so on).
+  </p>
+  <p>
+    Finally, it's not possible for a powerful feature to ever become "granted"
+    through any means provided by the Permissions Policy specification. The only
+    way that a powerful feature can be "granted" is through a user-agent
+    provided permission UI, or by some other user agent policy.
+  </p>
+</section>
 <section>
   <h2 id="permission-registry">
     Permission Registry


### PR DESCRIPTION
closes #176 

@clelland, would you mind taking a look? 

Hopefully this captures the delineation between the two specs correctly. I wonder if we should then add something over on the Permissions Policy spec to complement this?  