### PR TITLE
Fix link to GitHub repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         }],
         github: {
           branch: "main",
-          repoURL: "user/permissions",
+          repoURL: "w3c/permissions",
         },
         mdn: true,
         // See https://respec.org/docs/#xref for usage.


### PR DESCRIPTION
Links to ED and GitHub repository are currently broken in the spec because of this.