### PR TITLE
Define permission lifetimes

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,11 @@
           </dd>
         </dl>
         <p>
+          A user agent SHOULD provide a means for the user to view, update, and
+          reset the [=permission=] [=permission/state=] of [=powerful features=]
+          associated with a realm or origin.
+        </p>
+        <p>
           To ascertain <dfn class="export">new information about the user's intent</dfn>, a user
           agent MAY collect information about a user's intentions. This information can come from
           explicit user action, aggregate behavior of both the relevant user and other users, or
@@ -212,6 +217,44 @@
             implicit signals.
           </p>
         </aside>
+        <section>
+          <h4>Lifetimes</h4>
+          <p>
+            Every [=permission=] has a <dfn class="export" data-dfn-for="permission">lifetime</dfn>,
+            which is the duration for which a particular permission remains [=permission/granted=].
+            Depending on the [=powerful feature=], the lifetime of a permission is negotiated between the
+            user and the [=user agent=], usually via some permission UI or policy.
+          </p>
+          <p>
+            Specifications that identify themselves as <a>powerful feature</a> SHOULD suggest
+            a [=permission=] [=permission/lifetime=] that is best suited for the particular feature
+            - with a strong emphasis on user privacy.
+          </p>
+          <aside class="Note" title="Determining the lifetime of a permission">
+            <p>
+              For particularly privacy-sensitive [=features=], such as [[[GETUSERMEDIA]]],
+              which can provide access
+              to a user's camera and microphone, user agents are known to expire a permission
+              [=permission/grant=] as soon as a browser tab is closed or navigated.
+              For other features, like the [[[Geolocation]]], user agents are known to offer a choice of
+              only granting the permission for the session, or for one day. Others, like the [[[Notifications]]] and [[[Push]]] APIs,
+              remember a user's decision indefinitely or until the user manually denies the permission.
+            </p>
+            <p>
+              Finding the right balance for the lifetime of a permission requires a lot of
+              thought and experimentation, and often evolves over a long period of time (often years!).
+              Implementers are encouraged to work with their UX security teams to find the right balance
+              between ease of access to a [=powerful feature=] (i.e., reducing the number of permission prompts),
+              respecting a user's privacy, and making users aware when a web application is making use
+              of a particular powerful feature (e.g., via some visual or auditory UI indicator).
+            </p>
+            <p>
+              If you are unsure about what [=permission/lifetime=] to suggest for a [=powerful feature=],
+              please contact the <a href="https://www.w3.org/Privacy/IG/">Privacy Interest Group</a>
+              for guidance.
+            </p>
+          </aside>
+        </section>
       </section>
       <section>
         <h2>
@@ -390,7 +433,8 @@
             A <dfn class="export">default powerful feature</dfn> is a <a>powerful feature</a> with
             all of the above types and algorithms defaulted.
           </p>
-        </section>
+          </section>
+          </p>
         <section>
           <h3>
             Aspects

--- a/index.html
+++ b/index.html
@@ -404,9 +404,9 @@
               <p>
                 Specifications that identify themselves as a [=powerful feature=] SHOULD suggest a
                 [=permission=] [=permission/lifetime=] that is best suited for the particular
-                feature - with a strong emphasis on user privacy. Some guidance on determining the
-                lifetime of a permission is noted below. If no [=permission/lifetime=] is
-                specified, the user agent provides one.
+                feature. Some guidance on determining the lifetime of a permission is noted below,
+                with a strong emphasis on user privacy. If no [=permission/lifetime=] is specified,
+                the user agent provides one.
               </p>
               <p>
                 When the permission [=permission/lifetime=] expires for an origin, and if there are

--- a/index.html
+++ b/index.html
@@ -411,13 +411,17 @@
                 the user agent provides one.
               </p>
               <p>
-                When the permission [=permission/lifetime=] expires for a permission grant to an origin, and if there are
-                [=browsing contexts=] present pertaining to the [=permission=]'s associated origin,
-                the user agent MUST run the [=powerful feature/permission revocation algorithm=].
-                Alternatively, if there is no [=browsing context=] present, the user agent MUST
-                revoke a permission for the origin by setting it back to its default [=permission
-                state=] (e.g. setting it back to "[=permission/prompt=]").
+                When the permission [=permission/lifetime=] expires for an origin:
               </p>
+              <ol>
+                <li>Set the permission back to its default [=permission state=] (e.g. setting it
+                back to "[=permission/prompt=]").
+                </li>
+                <li>For each |browsing context| associated with the origin (if any), [=queue a
+                global task=] on the [=permissions task source=] with the |browsing context|'s
+                [=global object=] to run the [=powerful feature/permission revocation algorithm=].
+                </li>
+              </ol>
               <aside class="note" title="Determining the lifetime of a permission">
                 <p>
                   For particularly privacy-sensitive [=features=], such as [[[GETUSERMEDIA]]],

--- a/index.html
+++ b/index.html
@@ -198,9 +198,9 @@
           </dd>
         </dl>
         <p>
-          A user agent SHOULD provide a means for the user to view, update, and
-          reset the [=permission=] [=permission/state=] of [=powerful features=]
-          associated with a realm or origin.
+          A user agent SHOULD provide a means for the user to review, update, and reset the
+          [=permission=] [=permission/state=] of [=powerful features=] associated with a realm or
+          origin.
         </p>
         <p>
           To ascertain <dfn class="export">new information about the user's intent</dfn>, a user
@@ -217,44 +217,6 @@
             implicit signals.
           </p>
         </aside>
-        <section>
-          <h4>Lifetimes</h4>
-          <p>
-            Every [=permission=] has a <dfn class="export" data-dfn-for="permission">lifetime</dfn>,
-            which is the duration for which a particular permission remains [=permission/granted=].
-            Depending on the [=powerful feature=], the lifetime of a permission is negotiated between the
-            user and the [=user agent=], usually via some permission UI or policy.
-          </p>
-          <p>
-            Specifications that identify themselves as <a>powerful feature</a> SHOULD suggest
-            a [=permission=] [=permission/lifetime=] that is best suited for the particular feature
-            - with a strong emphasis on user privacy.
-          </p>
-          <aside class="Note" title="Determining the lifetime of a permission">
-            <p>
-              For particularly privacy-sensitive [=features=], such as [[[GETUSERMEDIA]]],
-              which can provide access
-              to a user's camera and microphone, user agents are known to expire a permission
-              [=permission/grant=] as soon as a browser tab is closed or navigated.
-              For other features, like the [[[Geolocation]]], user agents are known to offer a choice of
-              only granting the permission for the session, or for one day. Others, like the [[[Notifications]]] and [[[push-api]]] APIs,
-              remember a user's decision indefinitely or until the user manually denies the permission.
-            </p>
-            <p>
-              Finding the right balance for the lifetime of a permission requires a lot of
-              thought and experimentation, and often evolves over a long period of time (often years!).
-              Implementers are encouraged to work with their UX security teams to find the right balance
-              between ease of access to a [=powerful feature=] (i.e., reducing the number of permission prompts),
-              respecting a user's privacy, and making users aware when a web application is making use
-              of a particular powerful feature (e.g., via some visual or auditory UI indicator).
-            </p>
-            <p>
-              If you are unsure about what [=permission/lifetime=] to suggest for a [=powerful feature=],
-              please contact the <a href="https://www.w3.org/Privacy/IG/">Privacy Interest Group</a>
-              for guidance.
-            </p>
-          </aside>
-        </section>
       </section>
       <section>
         <h2>
@@ -427,6 +389,60 @@
               <p>
                 If unspecified, this defaults to running [=react to the user revoking permission=].
               </p>
+            </dd>
+            <dt>
+              A permission <dfn class="export" data-dfn-for="permission">lifetime</dfn>:
+            </dt>
+            <dd>
+              <p>
+                Every [=permission=] has a [=permission/lifetime=], which is the duration for which
+                a particular permission remains [=permission/granted=] before it reverts back to
+                its default [=permission state=]. The lifetime is negotiated between the end-user
+                and the [=user agent=] when the user gives [=express permission=] to use a
+                [=feature=] - usually via some permission UI or policy.
+              </p>
+              <p>
+                Specifications that identify themselves as a [=powerful feature=] SHOULD suggest a
+                [=permission=] [=permission/lifetime=] that is best suited for the particular
+                feature - with a strong emphasis on user privacy. Some guidance on determining the
+                lifetime of a permission is noted below. If no [=permission/lifetime=] is
+                specified, the user agent provides one.
+              </p>
+              <p>
+                When the permission [=permission/lifetime=] expires for an origin, and if there are
+                [=browsing contexts=] present pertaining to the [=permission=]'s associated origin,
+                the user agent MUST run the [=powerful feature/permission revocation algorithm=].
+                Alternatively, if there is no [=browsing contexts=] present, the user agent MUST
+                revoke a permission for the origin by setting it back to its default [=permission
+                state=] (e.g. setting it back to "[=permission/prompt=]").
+              </p>
+              <aside class="note" title="Determining the lifetime of a permission">
+                <p>
+                  For particularly privacy-sensitive [=features=], such as [[[GETUSERMEDIA]]],
+                  which can provide a web application access to a user's camera and microphone,
+                  user agents are known to expire a permission [=permission/grant=] as soon as a
+                  browser tab is closed or navigated. For other features, like the
+                  [[[Geolocation]]], user agents are known to offer a choice of only granting the
+                  permission for the session, or for one day. Others, like the [[[Notifications]]]
+                  and [[[push-api]]] APIs, remember a user's decision indefinitely or until the
+                  user manually denies the permission. Note that permission
+                  [=permission/lifetimes=] can vary significantly between user agents.
+                </p>
+                <p>
+                  Finding the right balance for the lifetime of a permission requires a lot of
+                  thought and experimentation, and often evolves over a long period of time (often
+                  years!). Implementers are encouraged to work with their UX security teams to find
+                  the right balance between ease of access to a [=powerful feature=] (i.e.,
+                  reducing the number of permission prompts), respecting a user's privacy, and
+                  making users aware when a web application is making use of a particular powerful
+                  feature (e.g., via some visual or auditory UI indicator).
+                </p>
+                <p>
+                  If you are unsure about what [=permission/lifetime=] to suggest for a [=powerful
+                  feature=], please contact the <a href="https://www.w3.org/Privacy/IG/">Privacy
+                  Interest Group</a> for guidance.
+                </p>
+              </aside>
             </dd>
           </dl>
           <p>

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
               to a user's camera and microphone, user agents are known to expire a permission
               [=permission/grant=] as soon as a browser tab is closed or navigated.
               For other features, like the [[[Geolocation]]], user agents are known to offer a choice of
-              only granting the permission for the session, or for one day. Others, like the [[[Notifications]]] and [[[Push]]] APIs,
+              only granting the permission for the session, or for one day. Others, like the [[[Notifications]]] and [[[push-api]]] APIs,
               remember a user's decision indefinitely or until the user manually denies the permission.
             </p>
             <p>

--- a/index.html
+++ b/index.html
@@ -433,7 +433,7 @@
             A <dfn class="export">default powerful feature</dfn> is a <a>powerful feature</a> with
             all of the above types and algorithms defaulted.
           </p>
-          </section>
+        </section>
         <section>
           <h3>
             Aspects

--- a/index.html
+++ b/index.html
@@ -397,22 +397,24 @@
               <p>
                 Every [=permission=] has a [=permission/lifetime=], which is the duration for which
                 a particular permission remains [=permission/granted=] before it reverts back to
-                its default [=permission state=]. The lifetime is negotiated between the end-user
+                its default [=permission state=]. 
+                A [=permission/lifetime=] could be until a particular Realm is destroyed, until a particular [=top-level browsing context=] is destroyed, an amount of time, or infinite.
+                The lifetime is negotiated between the end-user
                 and the [=user agent=] when the user gives [=express permission=] to use a
                 [=feature=] - usually via some permission UI or policy.
               </p>
               <p>
-                Specifications that identify themselves as a [=powerful feature=] SHOULD suggest a
+                Specifications that define one or more [=powerful features=] SHOULD suggest a
                 [=permission=] [=permission/lifetime=] that is best suited for the particular
                 feature. Some guidance on determining the lifetime of a permission is noted below,
                 with a strong emphasis on user privacy. If no [=permission/lifetime=] is specified,
                 the user agent provides one.
               </p>
               <p>
-                When the permission [=permission/lifetime=] expires for an origin, and if there are
+                When the permission [=permission/lifetime=] expires for a permission grant to an origin, and if there are
                 [=browsing contexts=] present pertaining to the [=permission=]'s associated origin,
                 the user agent MUST run the [=powerful feature/permission revocation algorithm=].
-                Alternatively, if there is no [=browsing contexts=] present, the user agent MUST
+                Alternatively, if there is no [=browsing context=] present, the user agent MUST
                 revoke a permission for the origin by setting it back to its default [=permission
                 state=] (e.g. setting it back to "[=permission/prompt=]").
               </p>
@@ -420,18 +422,18 @@
                 <p>
                   For particularly privacy-sensitive [=features=], such as [[[GETUSERMEDIA]]],
                   which can provide a web application access to a user's camera and microphone,
-                  user agents are known to expire a permission [=permission/grant=] as soon as a
+                  some user agents expire a permission [=permission/grant=] as soon as a
                   browser tab is closed or navigated. For other features, like the
                   [[[Geolocation]]], user agents are known to offer a choice of only granting the
                   permission for the session, or for one day. Others, like the [[[Notifications]]]
                   and [[[push-api]]] APIs, remember a user's decision indefinitely or until the
-                  user manually denies the permission. Note that permission
+                  user manually revokes the permission. Note that permission
                   [=permission/lifetimes=] can vary significantly between user agents.
                 </p>
                 <p>
                   Finding the right balance for the lifetime of a permission requires a lot of
-                  thought and experimentation, and often evolves over a long period of time (often
-                  years!). Implementers are encouraged to work with their UX security teams to find
+                  thought and experimentation, and often evolves over a period of years.
+                  Implementers are encouraged to work with their UX security teams to find
                   the right balance between ease of access to a [=powerful feature=] (i.e.,
                   reducing the number of permission prompts), respecting a user's privacy, and
                   making users aware when a web application is making use of a particular powerful

--- a/index.html
+++ b/index.html
@@ -434,7 +434,6 @@
             all of the above types and algorithms defaulted.
           </p>
           </section>
-          </p>
         <section>
           <h3>
             Aspects


### PR DESCRIPTION
closes #233 

Exports [=permission/lifetimes=].


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/287.html" title="Last updated on Nov 18, 2021, 8:01 AM UTC (69a5c32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/287/c3c5605...69a5c32.html" title="Last updated on Nov 18, 2021, 8:01 AM UTC (69a5c32)">Diff</a>