### PR TITLE
Remove MidiPermissionDescriptor, now in MIDI spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -846,22 +846,6 @@
           This [=powerful feature=] only has a single implementation, and therefore, as per the W3C
           Process, is [=at risk=].
         </p>
-        <dl>
-          <dt>
-            [=powerful feature/permission descriptor type=]
-          </dt>
-          <dd>
-            <pre class="idl">
-              dictionary MidiPermissionDescriptor : PermissionDescriptor {
-                boolean sysex = false;
-              };
-            </pre>
-            <p>
-              `{name: "midi", sysex: true}` is [=PermissionDescriptor/stronger than=] `{name:
-              "midi", sysex: false}`.
-            </p>
-          </dd>
-        </dl>
       </section>
       <section>
         <h3 id="screen-wake-lock">


### PR DESCRIPTION
See: https://github.com/WebAudio/web-midi-api/pull/219


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/304.html" title="Last updated on Oct 28, 2021, 1:59 AM UTC (66f940a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/304/136841b...66f940a.html" title="Last updated on Oct 28, 2021, 1:59 AM UTC (66f940a)">Diff</a>