### PR TITLE
Remove PushPermissionDescriptor, moved to Push API

### DIFF
--- a/index.html
+++ b/index.html
@@ -818,22 +818,6 @@
         <p>
           The <dfn>push</dfn> enum value identifies the [[[push-api]]] [=powerful feature=].
         </p>
-        <dl>
-          <dt>
-            [=powerful feature/permission descriptor type=]
-          </dt>
-          <dd>
-            <pre class="idl">
-              dictionary PushPermissionDescriptor : PermissionDescriptor {
-                boolean userVisibleOnly = false;
-              };
-            </pre>
-            <p>
-              `{name: "push", userVisibleOnly: false}` is [=PermissionDescriptor/stronger than=]
-              `{name: "push", userVisibleOnly: true}`.
-            </p>
-          </dd>
-        </dl>
       </section>
       <section>
         <h3 id="midi">


### PR DESCRIPTION
closes #293 

See: https://github.com/w3c/push-api/pull/341


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/305.html" title="Last updated on Oct 28, 2021, 2:01 AM UTC (84470db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/305/136841b...84470db.html" title="Last updated on Oct 28, 2021, 2:01 AM UTC (84470db)">Diff</a>