### PR TITLE
Remove ambient-light-sensor details defined in [[ambient-light]]

### DIFF
--- a/index.html
+++ b/index.html
@@ -994,11 +994,6 @@
           The <dfn>ambient-light-sensor</dfn> enum value identifies the [[[ambient-light]]] API
           [=powerful feature=].
         </p>
-        <p data-cite="generic-sensor">
-          Its [=powerful feature/permission revocation algorithm=] is the result of calling
-          [=generic sensor permission revocation algorithm=] passing it
-          {{PermissionName/"ambient-light-sensor"}} as argument.
-        </p>
       </section>
       <section>
         <h3 id="accelerometer">


### PR DESCRIPTION
closes #309 

We need https://github.com/w3c/ambient-light/pull/70 to land first before we can land this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/permissions/pull/310.html" title="Last updated on Nov 4, 2021, 1:40 AM UTC (5d6499c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/310/2dbcd62...miketaylr:5d6499c.html" title="Last updated on Nov 4, 2021, 1:40 AM UTC (5d6499c)">Diff</a>