### PR TITLE
Editorial: soft identify geolocation powerful feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,15 +792,10 @@
       <p>
         Each enumeration value in the {{PermissionName}} enum identifies a <a>powerful feature</a>.
       </p>
-      <section>
-        <h3 id="geolocation">
-          Geolocation
-        </h3>
-        <p>
-          The <dfn>geolocation</dfn> enum value identifies the [[[Geolocation]]] [=powerful
-          feature=]. It is a [=default powerful feature=].
-        </p>
-      </section>
+      <p>
+        The <dfn>geolocation</dfn> enum value identifies the [[[?Geolocation]]] [=powerful
+        feature=].
+      </p>
       <section>
         <h3 id="notifications">
           Notifications


### PR DESCRIPTION
Editorial change... Permission integration is now in the Geolocation spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/311.html" title="Last updated on Nov 4, 2021, 4:24 AM UTC (8d61c91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/311/136841b...8d61c91.html" title="Last updated on Nov 4, 2021, 4:24 AM UTC (8d61c91)">Diff</a>