### PR TITLE
Remove the allowed in non-secure contexts flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,20 +248,11 @@
             with us on this specification via GitHub.
           </p>
           <p>
-            Each <a>powerful feature</a> has the following permission-related flags, algorithms,
-            and types. When the defaults are not suitable for a particular [=powerful feature=], a
-            specification MAY override below flags, algorithms, and types below.
+            Each <a>powerful feature</a> has the following permission-related algorithms and types.
+            When the defaults are not suitable for a particular [=powerful feature=], a
+            specification MAY override below algorithms and types below.
           </p>
           <dl>
-            <dt>
-              An <dfn data-dfn-for="powerful feature" class="export">allowed in non-secure
-              contexts</dfn> flag:
-            </dt>
-            <dd>
-              By default, only <a>secure contexts</a> can use <a>powerful features</a>. If this
-              flag is set for a feature, the UA may grant access to it in <a>non-secure
-              contexts</a> too.
-            </dd>
             <dt>
               A <dfn data-dfn-for="powerful feature" class="export">permission descriptor
               type</dfn>:


### PR DESCRIPTION
closes #315

There are no longer any powerful features that use this flag (Notifications was the only one, and the 3 major engines removed that feature a few years back).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/permissions/pull/327.html" title="Last updated on Nov 19, 2021, 6:47 PM UTC (e425d01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/327/620ad6a...miketaylr:e425d01.html" title="Last updated on Nov 19, 2021, 6:47 PM UTC (e425d01)">Diff</a>