### PR TITLE
Editorial: link <a>express permission</a> inside <a>request permission to use</a>.

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,8 +519,8 @@
           <li>If <var>current state</var> is not {{PermissionState/"prompt"}}, return <var>current
           state</var> and abort these steps.
           </li>
-          <li>Ask the user's permission for the calling algorithm to use the <a>powerful
-          feature</a> described by |descriptor|.
+          <li>Ask the user for <a>express permission</a> for the calling algorithm to use the
+          <a>powerful feature</a> described by |descriptor|.
           </li>
           <li>If the user grants permission, return {{PermissionState/"granted"}}; otherwise return
           {{PermissionState/"denied"}}. The user's interaction may provide <a>new information about


### PR DESCRIPTION
r? @marcoscaceres 