### PR TITLE
Split Pri/Sec considerations + give user control over features

### DIFF
--- a/index.html
+++ b/index.html
@@ -997,7 +997,7 @@
         adversary to have discreet access to this information.
       </p>
       <p>
-        To mitigate this, a user agent SHOULD provide a means for the user to review, update, and
+        A user agent SHOULD provide a means for the user to review, update, and
         reset the [=permission=] [=permission/state=] of [=powerful features=] associated with a
         realm or origin.
       </p>

--- a/index.html
+++ b/index.html
@@ -989,30 +989,28 @@
         "https://w3c.github.io/permissions-automation/">Permissions Automation</a> document.
       </p>
     </section>
-    <section class="appendix informative">
+    <section class="appendix">
       <h2 id="privacy-considerations">
-        Security and privacy considerations
+        Privacy considerations
       </h2>
-      <p>
-        Web pages often run more- and less-trusted components as the same origin. For example, a
-        newspaper may run advertising code without sandboxing it into a cross-origin iframe. If the
-        newspaper has a legitimate reason to use a person's location, that also happens to grant
-        access to the less trusted advertiser. Without the {{Permissions/query()}} function in this
-        specification, to read the person's location, an advertisement needs to risk showing a
-        prompt, which exposes it to detection. With this function, the advertisement can silently
-        track just the people who've already granted their location to the newspaper. The UA might
-        provide notice of when permissions are in use on a page which might increase the visibility
-        of abuse.
-      </p>
       <p>
         An adversary could use a <a>permission state</a> as an element in creating a "fingerprint"
         corresponding to an end-user. Although an adversary can already determine the state of a
-        permission by actually using the API, that often leads to a permission request UI being
-        presented to the end-user (if the permission was not already
-        {{PermissionState/"granted"}}). Thus, even though this API doesn't expose new
-        fingerprinting information to websites, it makes it easier for an adversary to have
-        discreet access to this information. Thus, implementations are encouraged to have an option
-        for users to block (globally or selectively) the querying of <a>permission states</a>.
+        permission by actually using the API, that often leads to a UI prompt being presented to
+        the end-user (if the permission was not already [=permission/granted=]). Even though this
+        API doesn't expose new fingerprinting information to websites, it makes it easier for an
+        adversary to have discreet access to this information. Thus, implementations SHOULD provide
+        a means for users to control (globally or selectively) the [=permission states=]= of each
+        [=power feature=].
+      </p>
+    </section>
+    <section id="security-considerations">
+      <h2>
+        Security considerations
+      </h2>
+      <p>
+        There are no documented security considerations at this time. Readers are encouraged to
+        read section [[[#privacy-considerations]]] instead.
       </p>
     </section>
     <section id="idl-index"></section>

--- a/index.html
+++ b/index.html
@@ -1009,8 +1009,8 @@
         Security considerations
       </h2>
       <p>
-        There are no documented security considerations at this time. Readers are encouraged to
-        read section [[[#privacy-considerations]]] instead.
+        There are no documented security considerations at this time. Readers are instead
+        encouraged to read section [[[#privacy-considerations]]].
       </p>
     </section>
     <section id="idl-index"></section>

--- a/index.html
+++ b/index.html
@@ -198,11 +198,6 @@
           </dd>
         </dl>
         <p>
-          A user agent SHOULD provide a means for the user to review, update, and reset the
-          [=permission=] [=permission/state=] of [=powerful features=] associated with a realm or
-          origin.
-        </p>
-        <p>
           To ascertain <dfn class="export">new information about the user's intent</dfn>, a user
           agent MAY collect information about a user's intentions. This information can come from
           explicit user action, aggregate behavior of both the relevant user and other users, or
@@ -999,9 +994,12 @@
         permission by actually using the API, that often leads to a UI prompt being presented to
         the end-user (if the permission was not already [=permission/granted=]). Even though this
         API doesn't expose new fingerprinting information to websites, it makes it easier for an
-        adversary to have discreet access to this information. Thus, implementations SHOULD provide
-        a means for users to control (globally or selectively) the [=permission states=]= of each
-        [=power feature=].
+        adversary to have discreet access to this information.
+      </p>
+      <p>
+        To mitigate this, a user agent SHOULD provide a means for the user to review, update, and
+        reset the [=permission=] [=permission/state=] of [=powerful features=] associated with a
+        realm or origin.
       </p>
     </section>
     <section id="security-considerations">


### PR DESCRIPTION
The W3C now requires the Priv/Sec guidelines to be split into two sections (and they should be normative!).

Because the two existing paragraphs convey the same information (IMO), I got rid of the first paragraph; I found the second more clear. 

I also added a normative requirement:

> Thus, implementations SHOULD provide  a means for users to control (globally or selectively) the [=permission states=]= of each [=power feature=].

Which is basically "site settings" in various browsers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/344.html" title="Last updated on Feb 2, 2022, 1:51 AM UTC (01517f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/344/378b7fd...01517f6.html" title="Last updated on Feb 2, 2022, 1:51 AM UTC (01517f6)">Diff</a>