### PR TITLE
Editorial: run 'in parallel', not asynchronously

### DIFF
--- a/index.html
+++ b/index.html
@@ -712,17 +712,18 @@
             </li>
             <li>Let <var>promise</var> be a newly-created {{Promise}}.
             </li>
-            <li>Return <var>promise</var> and continue the following steps asynchronously.
-            </li>
-            <li>Run the steps to <a>create a `PermissionStatus`</a> for |typedDescriptor|, and let
-            |status| be the result.
-            </li>
-            <li>Let |query| be |status|'s {{PermissionStatus/[[query]]}} internal slot.
-            </li>
-            <li>Run |query|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission query
-            algorithm=], passing |query| and |status|.
-            </li>
-            <li>Resolve <var>promise</var> with |status|.
+            <li>Return <var>promise</var> and continue [=in parallel=]:
+              <ol>
+                <li>Let |status| be <a>create a `PermissionStatus`</a> with |typedDescriptor|.
+                </li>
+                <li>Let |query| be |status|'s {{PermissionStatus/[[query]]}} internal slot.
+                </li>
+                <li>Run |query|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission
+                query algorithm=], passing |query| and |status|.
+                </li>
+                <li>Resolve <var>promise</var> with |status|.
+                </li>
+              </ol>
             </li>
           </ol>
         </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/352.html" title="Last updated on Feb 4, 2022, 5:50 AM UTC (15db4ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/352/01ae676...15db4ba.html" title="Last updated on Feb 4, 2022, 5:50 AM UTC (15db4ba)">Diff</a>