### PR TITLE
Editorial: Add linking-text for "specifies a powerful feature"

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,8 @@
         Specifying a powerful feature
       </h2>
       <p>
-        When a specification <dfn class="export">specifies a powerful feature</dfn> it:
+        When a specification <dfn data-lt="specify a powerful feature" class="export">specifies a
+        powerful feature</dfn> it:
       </p>
       <ol>
         <li>MUST give the [=powerful feature=] a [powerful feature/name] in the form of a [=ascii


### PR DESCRIPTION
Adding this so the link works as expected in https://github.com/w3c/powerful-features-registry/pull/5