### PR TITLE
Editorial: move [=extra permission data=] out of example

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,15 +363,19 @@
           <dfn data-dfn-for="powerful feature" class="export">extra permission data type</dfn>:
         </dt>
         <dd>
-          <p class="note" data-cite="mediacapture-streams ECMAScript">
+          <p>
             Some <a>powerful features</a> have more information associated with them than just a
-            {{PermissionState}}. For example, {{MediaDevices/getUserMedia()}} needs to determine
-            <em>which</em> cameras the user has granted [=ECMAScript/the current realm record=]
-            permission to access. Each of these features defines an [=powerful feature/extra
-            permission data type=]. If a {{DOMString}} |name| names one of these features, then
-            |name|'s <dfn data-dfn-for="powerful feature" class="export">extra permission
-            data</dfn> for an optional <a>environment settings object</a> |settings| is the result
-            of the following algorithm:
+            {{PermissionState}}. Each of these features defines an [=powerful feature/extra
+            permission data type=].
+          </p>
+          <p class="note" data-cite="mediacapture-streams ECMAScript">
+            For example, {{MediaDevices/getUserMedia()}} needs to determine <em>which</em> cameras
+            the user has granted [=ECMAScript/the current realm record=] permission to access.
+          </p>
+          <p>
+            If a {{DOMString}} |name| names one of these features, then |name|'s <dfn data-dfn-for=
+            "powerful feature" class="export">extra permission data</dfn> for an optional
+            <a>environment settings object</a> |settings| is the result of the following algorithm:
           </p>
           <ol class="algorithm">
             <li>If |settings| wasn't passed, set it to the [=current settings object=].


### PR DESCRIPTION
closes #369

(seems like it was accidentally put in there)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/permissions/pull/370.html" title="Last updated on Mar 2, 2022, 2:28 PM UTC (0130ad7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/370/4c4eebc...miketaylr:0130ad7.html" title="Last updated on Mar 2, 2022, 2:28 PM UTC (0130ad7)">Diff</a>