### PR TITLE
Allow "prompt the user to choose" apply to one or more options.

### DIFF
--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@
           {{PermissionState/"denied"}} and abort these steps.
           </li>
           <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"granted"}}, the user
-          agent may return one or more of |options| chosen by the user and abort these steps. If the user agent
+          agent may return one (or more if |allowMultiple| is true) of |options| chosen by the user and abort these steps. If the user agent
           returns without prompting, then subsequent <a data-lt="prompt the user to choose">prompts
           for the user to choose</a> from the same set of options with the same |descriptor| must
           return the same option(s), unless the user agent receives <a>new information about the

--- a/index.html
+++ b/index.html
@@ -662,11 +662,11 @@
           {{PermissionState/"denied"}} and abort these steps.
           </li>
           <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"granted"}}, the user
-          agent may return one (or more if |allowMultiple| is true) of |options| chosen by the user and abort these steps. If the user agent
-          returns without prompting, then subsequent <a data-lt="prompt the user to choose">prompts
-          for the user to choose</a> from the same set of options with the same |descriptor| must
-          return the same option(s), unless the user agent receives <a>new information about the
-          user's intent</a>.
+          agent may return one (or more if |allowMultiple| is true) of |options| chosen by the user
+          and abort these steps. If the user agent returns without prompting, then subsequent
+          <a data-lt="prompt the user to choose">prompts for the user to choose</a> from the same
+          set of options with the same |descriptor| must return the same option(s), unless the user
+          agent receives <a>new information about the user's intent</a>.
           </li>
           <li>Ask the user to choose one or more |options| or deny permission, and wait for them to
           choose:

--- a/index.html
+++ b/index.html
@@ -652,26 +652,26 @@
         </h3>
         <p>
           To <dfn data-lt="prompt the user to choose|prompting the user to choose" class=
-          "export">prompt the user to choose</dfn> one of several |options| associated with a
-          |descriptor|, the user agent must perform the following steps. This algorithm returns
-          either {{PermissionState/"denied"}} or one of the options.
+          "export">prompt the user to choose</dfn> one or more of several |options| associated with
+          a |descriptor|, the user agent must perform the following steps. This algorithm returns
+          either {{PermissionState/"denied"}} or the selected option(s).
         </p>
         <ol class="algorithm">
           <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"denied"}}, return
           {{PermissionState/"denied"}} and abort these steps.
           </li>
           <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"granted"}}, the user
-          agent may return one of |options| and abort these steps. If the user agent returns
-          without prompting, then subsequent <a data-lt="prompt the user to choose">prompts for the
-          user to choose</a> from the same set of options with the same |descriptor| must return
-          the same option, unless the user agent receives <a>new information about the user's
-          intent</a>.
+          agent may return one or more of |options| and abort these steps. If the user agent
+          returns without prompting, then subsequent <a data-lt="prompt the user to choose">prompts
+          for the user to choose</a> from the same set of options with the same |descriptor| must
+          return the same option(s), unless the user agent receives <a>new information about the
+          user's intent</a>.
           </li>
-          <li>Ask the user to choose one of the options or deny permission, and wait for them to
-          choose. If the calling algorithm specified extra information to include in the prompt,
-          include it.
+          <li>Ask the user to choose one or more of the options or deny permission, and wait for
+          them to choose. If the calling algorithm specified extra information to include in the
+          prompt, include it.
           </li>
-          <li>If the user chooses an option, return it; otherwise return
+          <li>If the user choose one or more options, return them; otherwise return
           {{PermissionState/"denied"}}. If the user's interaction indicates they intend this choice
           to apply to other realms, then treat this this as <a>new information about the user's
           intent</a> for other [=global object/realms=] with the <a>same origin</a>.

--- a/index.html
+++ b/index.html
@@ -652,26 +652,34 @@
         </h3>
         <p>
           To <dfn data-lt="prompt the user to choose|prompting the user to choose" class=
-          "export">prompt the user to choose</dfn> one or more of several |options| associated with
-          a |descriptor|, the user agent must perform the following steps. This algorithm returns
-          either {{PermissionState/"denied"}} or the selected option(s).
+          "export">prompt the user to choose</dfn> one or more |options| associated with a given
+          |descriptor:PermissionDescriptor| and an optional <a>boolean</a> |allowMultiple:boolean|
+          (default false), the user agent must perform the following steps. This algorithm returns
+          either {{PermissionState/"denied"}} or the user's selection.
         </p>
         <ol class="algorithm">
           <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"denied"}}, return
           {{PermissionState/"denied"}} and abort these steps.
           </li>
           <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"granted"}}, the user
-          agent may return one or more of |options| and abort these steps. If the user agent
+          agent may return one or more of |options| chosen by the user and abort these steps. If the user agent
           returns without prompting, then subsequent <a data-lt="prompt the user to choose">prompts
           for the user to choose</a> from the same set of options with the same |descriptor| must
           return the same option(s), unless the user agent receives <a>new information about the
           user's intent</a>.
           </li>
-          <li>Ask the user to choose one or more of the options or deny permission, and wait for
-          them to choose. If the calling algorithm specified extra information to include in the
-          prompt, include it.
+          <li>Ask the user to choose one or more |options| or deny permission, and wait for them to
+          choose:
+            <ol>
+              <li>If the calling algorithm specified extra information to include in the prompt,
+              include it.
+              </li>
+              <li>If |allowMultiple| is false, restrict selection to a single item from |options|;
+              otherwise, any number may be selected by the user.
+              </li>
+            </ol>
           </li>
-          <li>If the user choose one or more options, return them; otherwise return
+          <li>If the user chose one or more options, return them; otherwise return
           {{PermissionState/"denied"}}. If the user's interaction indicates they intend this choice
           to apply to other realms, then treat this this as <a>new information about the user's
           intent</a> for other [=global object/realms=] with the <a>same origin</a>.


### PR DESCRIPTION
closes #375

A PR for discussion. PTAL @marcoscaceres


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 23, 2022, 6:26 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmiketaylr%2Fpermissions%2Fd0c11a15df5aa76e285cafd1925f2d3c9480b527%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/OUQ0MZ
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/permissions%23376.)._
</details>
