### PR TITLE
chore: Remove reference to issue #278

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,8 +601,6 @@
           |descriptor|'s {{PermissionDescriptor/name}}.
           </li>
         </ol>
-        <aside class="issue" id="issue-current-entry-incumbent-or-relevant" data-number="278">
-        </aside>
         <p>
           As a shorthand, a {{DOMString}} |name|'s <a>permission state</a> is the <a>permission
           state</a> of a {{PermissionDescriptor}} with its {{PermissionDescriptor/name}} member set


### PR DESCRIPTION
I propose to close it as invalid, see https://github.com/w3c/permissions/issues/278#issuecomment-1137774977

closes #278


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 25, 2022, 7:44 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmiketaylr%2Fpermissions%2F8a506308fa509f7ee2f133e835445ea07edef900%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/Y5gFB4
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/permissions%23380.)._
</details>
