### PR TITLE
Meta: remove local-lt for <dfn>permission state<dfn>

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,9 +570,9 @@
           </li>
         </ol>
         <p>
-          A |descriptor|'s <dfn class="export" data-local-lt="state">permission state</dfn>, given
-          an optional <a>environment settings object</a> |settings| is the result of the following
-          algorithm. It returns a {{PermissionState}} enum value:
+          A |descriptor|'s <dfn class="export">permission state</dfn>, given an optional
+          <a>environment settings object</a> |settings| is the result of the following algorithm.
+          It returns a {{PermissionState}} enum value:
         </p>
         <ol class="algorithm">
           <li>If |settings| wasn't passed, set it to the [=current settings object=].


### PR DESCRIPTION
We already have local-lt="state" for https://w3c.github.io/permissions/#dfn-states, and it seems easier to understand if we explicitly use `<a>permission state</a>`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/permissions/pull/385.html" title="Last updated on Oct 18, 2022, 1:50 AM UTC (7c01d13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/385/698e614...miketaylr:7c01d13.html" title="Last updated on Oct 18, 2022, 1:50 AM UTC (7c01d13)">Diff</a>