### PR TITLE
Define a permission store (closes #384)

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,18 +859,21 @@
         </h3>
         <p>
           When the user agent learns that the user no longer intends to grant permission to use a
-          <a>feature</a>, <dfn>react to the user revoking permission</dfn> by running these steps:
+          feature described by the {{PermissionDescriptor}} |descriptor| in the context
+          described by the [=permission key=] |key|, <dfn>react to the user revoking permission</dfn>
+          by running these steps:
         </p>
         <ol class="algorithm">
           <li>
-            <a>Queue a global task</a> on the [=user interaction task source=] to run that
-            feature's [=powerful feature/permission revocation algorithm=].
-          </li>
-          <li>
-            Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission key=] with the Realm's [=Realm/settings object=].
-          </li>
-          <li>
-            TODO: How do I get the feature descriptor to remove the feature here?
+            <a>Queue a global task</a> on the [=user interaction task source=] to:.
+            <ol>
+              <li>
+                Run |descriptor|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission revocation algorithm=].
+              </li>
+              <li>
+                [=Remove a permission store entry=] with |descriptor| and |key|.
+              </li>
+            </ol>
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -289,12 +289,13 @@
           The user agent MAY remove [=entries=] from the [=permission store=] when their respective [=permission=]'s [=permission/lifetime=] has expired.
         </p>
         <p>
-          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, an instance <dfn class="export" data-dfn-for="permission store entry">key</dfn> of the [=powerful feature/permission key type=] of the feature named by [=permission store entry/descriptor=].name, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
+          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, [=permission key=] <dfn class="export" data-dfn-for="permission store entry">key</dfn>, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
         </p>
         <p>
         To <dfn class="export">get a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor| and [=permission key=] |key|:
           <ol class="algorithm">
             <li>
+              <!-- TODO: PermissionDescriptor equality is not defined (#396) -->
               If the user agent's [=permission store=] [=list/contains=] an [=entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, return that entry.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@
             </li>
           </ol>
           <aside class="note" title="Permission Delegation">
-            Most powerful features grant permission to the top-level origin and delegate access to the requesting document via [[[webappsec-permissions-policy]]].
+            Most powerful features grant permission to the top-level origin and delegate access to the requesting document via [[[Permissions-Policy]]].
             This is known as permission delegation.
           </aside>
         </dd>

--- a/index.html
+++ b/index.html
@@ -289,19 +289,13 @@
           The user agent MAY remove [=entries=] from the [=permission store=] when their respective [=permission=]'s [=permission/lifetime=] has expired.
         </p>
         <p>
-          The user agent MAY maintain additional permission stores with [=implementation-defined=] scope and eviction rules. Which permission store is adressed in a given moment is [=implementation-defined=].
-          <aside class="note">
-            This is intended to allow a user agent to experiment with user-friendly permission concepts such as per-tab grants.
-          </aside>
+          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, [=permission key=] <dfn class="export" data-dfn-for="permission store entry">key</dfn>, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
         </p>
         <p>
-          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of [=powerful feature/name=] <dfn>name</dfn>, [=permission store key=] <dfn>key</dfn>, {{PermissionDescriptor}} <dfn>descriptor</dfn>, and [=permission/state=] <dfn>state</dfn>.
-        </p>
-        <p>
-          To <dfn class="export">get a permission store entry</dfn> from the user agent's permission store given a |name|, [=permission store key=] key and descriptor, run these steps:
+        To <dfn class="export">get a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor| and [=permission key=] |key|, run these steps:
           <ol class="algorithm">
             <li>
-              If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor|, return that entry.
+              If the user agent's [=permission store=] [=list/contains=] an [=entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, return that entry.
             </li>
             <li>
               Return null.
@@ -309,34 +303,42 @@
           </ol>
         </p>
         <p>
-          To <dfn class="export">set a permission store entry</dfn> in the user agent's permission store given a [=powerful feature/name=] |name|, a [=permission store key=] |key|, a {{PermissionDescriptor}} |descriptor|, and a [=permission/state=] |state|, run these steps:
+          To <dfn class="export">set a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor|, a [=permission key=] |key|, and a [=permission/state=] |state|, run these steps:
           <ol class="algorithm">
             <li>
-              Let |newEntry| be a new [=permission store entry=] with the [=name=] |name|, [=key=] |key|, [=descriptor=] |descriptor|, and [=state=] |state|.
+              Let |newEntry| be a new [=permission store entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, and whose [=permission store entry/state=] is |state|.
             </li>
             <li>
-              If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, the [=key=] |key| and the [=descriptor=] |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.
+              If the user agent's [=permission store=] [=list/contains=] an [=entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.
             </li>
             <li>
-              [=list/append=] |newEntry| to the permission store.
+              [=list/Append=] |newEntry| to the user agent's [=permission store=].
             </li>
           </ol>
         </p>
         <p>
-          To <dfn class="export">remove a permission store entry</dfn> from the permission store given a name, key and descriptor, run these steps:
+          To <dfn class="export">remove a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor| and [=permission key=] |key|, run these steps:
           <ol class="algorithm">
             <li>
-            [=list/Remove=] the [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor| from the permission store.
+            [=list/Remove=] the [=entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, from the user agent's [=permission store=].
             </li>
           </ol>
         </p>
         <p>
-          A <dfn class="export">permission store key</dfn> has the type returned by the feature's [=powerful feature/permission key generation algorithm=].
+          A <dfn class="export">permission key</dfn> has the type returned by the feature's [=powerful feature/permission key generation algorithm=].
           <aside class="note">
-            Powerful features may override the key generation algorithm to specify a custom permission store key.
+            Powerful features may override the key generation algorithm to specify a custom permission key.
             This is useful for features that want to restrict permissions based on additional context,
             such as double-keying on both the embedded origin and the top-level origin.
           </aside>
+        </p>
+        <p>
+          To determine whether a [=permission key=] |key1| <dfn class="export" for="permission key">is equal to</dfn> a [=permission key=] |key2|, given a {{PermissionDescriptor}} |descriptor|, run the following steps:
+          <ol class="algorithm">
+            <li>
+              Return the result of running |descriptor|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission key comparison algorithm=], passing |key1| and |key2|.
+            </li>
+          </ol>
         </p>
 
         </p>
@@ -569,23 +571,23 @@
         </dt>
         <dd>
           <p>
-            Takes an [=environment settings object=], and returns a new [=permission store key=].
+            Takes an [=environment settings object=], and returns a new [=permission key=].
             If unspecified, this defaults to the <a>default permission key generation algorithm</a>.
             A feature that specifies a custom [=powerful feature/permission key generation algorithm=] MUST also specify a
             [=powerful feature/permission key comparison algorithm=].
           </p>
           <p>
-            The <dfn data-export="">default permission key generation algorithm</dfn>,
+            The <dfn class="export">default permission key generation algorithm</dfn>,
             given an [=environment settings object=] |settings|, runs the following steps:
           </p>
           <ol class="algorithm">
             <li>
-              Return |settings|' [=environment/top-level origin=].
+              Return |settings|'s [=environment/top-level origin=].
             </li>
           </ol>
           <aside class="note" title="Permission Delegation">
             Most powerful features grant permission to the top-level origin and delegate access to the requesting document via Permissions Policy.
-            This is called Permission Delegation.
+            This is known as permission delegation.
           </aside>
         </dd>
         <dt>
@@ -593,14 +595,17 @@
         </dt>
         <dd>
           <p>
-            Takes two [=permission store keys=] and returns a boolean that shows whether the two keys are equal.
+            Takes two [=permission keys=] and returns a boolean that shows whether the two keys are equal.
             If unspecified, this defaults to the <a>default permission key comparison algorithm</a>.
           </p>
           <p>
-            The <dfn data-export="">default permission key comparison algorithm</dfn>,
-            given [=permission store keys=] |key1| and |key2| (both [=origins=]), runs the following steps:
+            The <dfn class="export">default permission key comparison algorithm</dfn>,
+            given [=permission keys=] |key1| and |key2|, runs the following steps:
           </p>
           <ol class="algorithm">
+            <li>
+              If |key1| is not an [=origin=] or |key2| is not an [=origin=] return false.
+            </li>
             <li>
               If |key1| is not [=same origin=] with |key2| return false.
             </li>
@@ -736,11 +741,11 @@
               </li>
             </ol>
           </li>
-          <li>Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission store key=] with |settings|.
+          <li>Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission key=] with |settings|.
           </li>
-          <li>Let |entry| be the result of [=get a permission store entry|getting a permission store entry=] with |feature|, |descriptor| and |key|.
+          <li>Let |entry| be the result of [=get a permission store entry|getting a permission store entry=] with |descriptor| and |key|.
           </li>
-          <li>If |entry| is not null, return a {{PermissionState}} enum value from |entry|'s state and name.
+          <li>If |entry| is not null, return a {{PermissionState}} enum value from |entry|'s [=permission store entry/state=] and |entry|'s [=permission store entry/descriptor=]'s {{PermissionDescriptor/name}}.
           </li>
           <li>Return the {{PermissionState}} enum value that represents the permission state of
           |feature|, taking into account any [=powerful feature/permission state constraints=] for
@@ -783,11 +788,11 @@
             </p>
           </li>
           <li>
-            Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission store key=] with the [=current settings object=].
+            Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission key=] with the [=current settings object=].
           </li>
           <li>
             [=Queue a task=] on the [=current settings object=]'s [=environment settings
-            object/responsible event loop=] to [=set a permission store entry=] with |descriptor|'s name, |key|, |descriptor|, and |current state|.
+            object/responsible event loop=] to [=set a permission store entry=] with |descriptor|, |key|, and |current state|.
           </li>
           <li>
             Return |current state|.
@@ -862,7 +867,7 @@
             feature's [=powerful feature/permission revocation algorithm=].
           </li>
           <li>
-            Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission store key=] with the Realm's [=Realm/settings object=].
+            Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission key=] with the Realm's [=Realm/settings object=].
           </li>
           <li>
             TODO: How do I get the feature descriptor to remove the feature here?

--- a/index.html
+++ b/index.html
@@ -617,10 +617,7 @@
           </p>
           <ol class="algorithm">
             <li>
-              If |key1| is not [=same origin=] with |key2| return false.
-            </li>
-            <li>
-              Return true.
+              Return |key1| is [=same origin=] with |key2|.
             </li>
           </ol>
         </dd>

--- a/index.html
+++ b/index.html
@@ -279,6 +279,93 @@
         </p>
       </section>
       <section>
+        <h3>
+          Permission Store
+        </h3>
+        <p>
+        The user agent maintains a single <dfn class="export">global permission store</dfn> which is a list of [=permission store entries=].
+        The user agent removes [=entries=] from the list when their respective [=permission=]'s [=permission/lifetime=] has expired.
+        </p>
+        <p class="issue">
+        We should still allow UAs flexibility in giving out permissions with smaller scope and lifetime (e.g. per-tab) in some form. There should generally still be enough room for exploration here.
+        </p>
+        <p>
+        A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of [=powerful feature/name=] name, [=permission store key=] key, {{PermissionDescriptor}} descriptor, and [=permission/state=] state.
+        </p>
+        <p>
+        To <dfn class="export">get a permission store entry</dfn> from the [=global permission store=] given a |name|, [=permission store key=] key and descriptor, run these steps:
+        <ol class="algorithm">
+          <li>
+          If the [=global permission store=] [=list/contains=] an [=entry=] with the name |name|, the key |key| and the descriptor |descriptor|, return that entry.
+          </li>
+          <li>
+          Return null.
+          </li>
+        </ol>
+        </p>
+        <p>
+        To <dfn class="export">set a permission store entry</dfn> in the [=global permission store=] given a [=powerful feature/name=] |name|, a [=permission store key=] |key|, a {{PermissionDescriptor}} |descriptor|, and a [=permission/state=] |state|, run these steps:
+        <ol class="algorithm">
+          <li>
+            Let |newEntry| be a new [=permission store entry=] with |name|, |key|, |descriptor|, and |state|.
+          </li>
+          <li>
+            If the [=global permission store=] [=list/contains=] an [=entry=] with the name |name|, the key |key| and the descriptor |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.
+          </li>
+          <li>
+            Otherwise, [=list/append=] |newEntry| to the [=global permission store=].
+          </li>
+        </ol>
+        </p>
+        <p>
+        To <dfn class="export">remove a permission store entry</dfn> from the [=global permission store=] given a name, key and descriptor, run these steps:
+        <ol class="algorithm">
+          <li>
+          [=list/Remove=] the [=entry=] with the name |name|, key |key| and descriptor |descriptor| from the [=global permission store=].
+          </li>
+        </ol>
+        </p>
+        <p>
+        A <dfn class="export">permission store key</dfn> is a [=tuple=] of ([=origin=] top-level origin, [=origin=] embedded origin).
+        </p>
+
+        <p>
+        To <dfn class="export">generate a permission store key</dfn> `key` given [=environment settings object=] |settings|, run these steps:
+        <ol class="algorithm">
+          <li>
+            Let |top-level origin| be |settings|' [=environment/top-level origin=].
+          </li>
+          <li>
+            Return (|top-level origin|, null)
+          </li>
+          <p class="issue">
+          How do we ensure that other specs can override this? Should we add all key deviations as new steps to this algorithm or have a different override mechanism?
+          </p>
+          <p class="note">
+            Most permissions will want to key on the top-level origin and delegate access via Permissions Policy.
+            However, others, like the Storage Access API, explicitly describe a embeddee relationship and need to use the
+            embedded origin field.
+          </p>
+          <p class="note">
+            This assumes that passed in settings is from the embedded document.
+          </p>
+        </ol>
+        </p>
+
+        <p>
+        To <dfn class="export">compare [=permission store keys=]</dfn> |key1| and |key2|, run these steps:
+        <ol class="algorithm">
+          <li>
+          </li>
+        </ol>
+        <p class="issue">
+        Do we have to define this? If we can compare origins we can probably implicitly compare a tuple of origins?
+        </p>
+        </p>
+
+        </p>
+      </section>
+      <section>
         <h2>
           Powerful features
         </h2>
@@ -509,7 +596,7 @@
           <p>
             Takes no arguments. Updates any other parts of the implementation that need to be kept
             in sync with changes in the results of <a>permission states</a> or [=powerful
-            feature/extra permission data=], and then [=react to the user revoking permission=].
+            feature/extra permission data=].
           </p>
           <p>
             If unspecified, this defaults to running [=react to the user revoking permission=].
@@ -628,9 +715,11 @@
               </li>
             </ol>
           </li>
-          <li>If there was a previous invocation of this algorithm with the same |descriptor| and
-          |settings|, returning |previousResult|, and the user agent has not received <a>new
-          information about the user's intent</a> since that invocation, return |previousResult|.
+          <li>Let |key| be the result of [=generate a permission store key|generating a permission store key=] with |settings|.
+          </li>
+          <li>Let |entry| be the result of [=get a permission store entry|getting a permission store entry=] with |feature|, |descriptor| and |key|.
+          </li>
+          <li>If |entry| is not null, return a {{PermissionState}} enum value from |entry|'s state and name.
           </li>
           <li>Return the {{PermissionState}} enum value that represents the permission state of
           |feature|, taking into account any [=powerful feature/permission state constraints=] for
@@ -662,8 +751,8 @@
           <li>Ask the user for <a>express permission</a> for the calling algorithm to use the
           <a>powerful feature</a> described by |descriptor|.
           </li>
-          <li>If the user gives [=express permission=] to use the powerful feature, return
-          {{PermissionState/"granted"}}; otherwise return {{PermissionState/"denied"}}. The user's
+          <li>If the user gives [=express permission=] to use the powerful feature, set |current state| to
+          {{PermissionState/"granted"}}; otherwise to {{PermissionState/"denied"}}. The user's
           interaction may provide <a>new information about the user's intent</a> for the
           [=origin=].
             <p class="note">
@@ -671,6 +760,16 @@
               agent infers user intent. User agents should be able to explore lots of UI within
               this framework.
             </p>
+          </li>
+          <li>
+            Let |key| be the result of [=generate a permission store key|generating a permission store key=] with the [=current settings object=].
+          </li>
+          <li>
+            [=Queue a task=] on the [=current settings object=]'s [=environment settings
+            object/responsible event loop=] to [=set a permission store entry=] with |descriptor|'s name, |key|, |descriptor|, and |current state|.
+          </li>
+          <li>
+            Return |current state|.
           </li>
         </ol>
         <p>
@@ -740,6 +839,12 @@
           <li>
             <a>Queue a global task</a> on the [=user interaction task source=] to run that
             feature's [=powerful feature/permission revocation algorithm=].
+          </li>
+          <li>
+            Let |key| be the result of [=generate a permission store key|generating a permission store key=] with the Realm's [=Realm/settings object=].
+          </li>
+          <li>
+            TODO: How do I get the feature descriptor to remove the feature here?
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -283,20 +283,25 @@
           Permission Store
         </h3>
         <p>
-        The user agent maintains a single <dfn class="export">permission store</dfn> which is a [=/list=] of [=permission store entries=].
-        The user agent removes [=entries=] from the list when their respective [=permission=]'s [=permission/lifetime=] has expired.
-        </p>
-        <p class="issue">
-        We should still allow UAs flexibility in giving out permissions with smaller scope and lifetime (e.g. per-tab) in some form. There should generally still be enough room for exploration here.
+          The user agent maintains a single <dfn class="export">permission store</dfn> which is a [=/list=] of [=permission store entries=].
         </p>
         <p>
-        A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of [=powerful feature/name=] name, [=permission store key=] key, {{PermissionDescriptor}} descriptor, and [=permission/state=] state.
+          The user agent MAY remove [=entries=] from the [=permission store=] when their respective [=permission=]'s [=permission/lifetime=] has expired.
         </p>
         <p>
-        To <dfn class="export">get a permission store entry</dfn> from the [=global permission store=] given a |name|, [=permission store key=] key and descriptor, run these steps:
+          The user agent MAY maintain additional permission stores with [=implementation-defined=] scope and eviction rules. Which permission store is adressed in a given moment is [=implementation-defined=].
+          <p class="note">
+            This is intended to allow a user agent to experiment with user-friendly permission concepts such as per-tab grants.
+          </p>
+        </p>
+        <p>
+        A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of [=powerful feature/name=] <dfn>name</dfn>, [=permission store key=] <dfn>key</dfn>, {{PermissionDescriptor}} <dfn>descriptor</dfn>, and [=permission/state=] <dfn>state</dfn>.
+        </p>
+        <p>
+        To <dfn class="export">get a permission store entry</dfn> from the user agent's permission store given a |name|, [=permission store key=] key and descriptor, run these steps:
         <ol class="algorithm">
           <li>
-          If the [=global permission store=] [=list/contains=] an [=entry=] with the name |name|, the key |key| and the descriptor |descriptor|, return that entry.
+          If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor|, return that entry.
           </li>
           <li>
           Return null.
@@ -304,50 +309,43 @@
         </ol>
         </p>
         <p>
-        To <dfn class="export">set a permission store entry</dfn> in the [=global permission store=] given a [=powerful feature/name=] |name|, a [=permission store key=] |key|, a {{PermissionDescriptor}} |descriptor|, and a [=permission/state=] |state|, run these steps:
+        To <dfn class="export">set a permission store entry</dfn> in the user agent's permission store given a [=powerful feature/name=] |name|, a [=permission store key=] |key|, a {{PermissionDescriptor}} |descriptor|, and a [=permission/state=] |state|, run these steps:
         <ol class="algorithm">
           <li>
-            Let |newEntry| be a new [=permission store entry=] with |name|, |key|, |descriptor|, and |state|.
+            Let |newEntry| be a new [=permission store entry=] with the [=name=] |name|, [=key=] |key|, [=descriptor=] |descriptor|, and [=state=] |state|.
           </li>
           <li>
-            If the [=global permission store=] [=list/contains=] an [=entry=] with the name |name|, the key |key| and the descriptor |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.
+            If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, the [=key=] |key| and the [=descriptor=] |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.
           </li>
           <li>
-            Otherwise, [=list/append=] |newEntry| to the [=global permission store=].
+            [=list/append=] |newEntry| to the permission store.
           </li>
         </ol>
         </p>
         <p>
-        To <dfn class="export">remove a permission store entry</dfn> from the [=global permission store=] given a name, key and descriptor, run these steps:
+        To <dfn class="export">remove a permission store entry</dfn> from the permission store given a name, key and descriptor, run these steps:
         <ol class="algorithm">
           <li>
-          [=list/Remove=] the [=entry=] with the name |name|, key |key| and descriptor |descriptor| from the [=global permission store=].
+          [=list/Remove=] the [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor| from the permission store.
           </li>
         </ol>
         </p>
         <p>
-        A <dfn class="export">permission store key</dfn> is a [=tuple=] of ([=origin=] top-level origin, [=origin=] embedded origin).
+        A <dfn class="export">permission store key</dfn> is a [=tuple=] of ([=origin=] <dfn data-dfn-for="permission store key">top-level origin</dfn>, [=origin=] <dfn data-dfn-for="permission store key">granted origin</dfn>).
         </p>
 
         <p>
         To <dfn class="export">generate a permission store key</dfn> given [=environment settings object=] |settings|, run these steps:
         <ol class="algorithm">
           <li>
-            Let |top-level origin| be |settings|' [=environment/top-level origin=].
+            Let |topLevelOrigin| be |settings|' [=environment/top-level origin=].
           </li>
           <li>
-            Return (|top-level origin|, null).
+            Return (|topLevelOrigin|, |topLevelOrigin|).
           </li>
-          <p class="issue">
-          How do we ensure that other specs can override this? Should we add all key deviations as new steps to this algorithm or have a different override mechanism?
-          </p>
           <p class="note">
-            Most permissions will want to key on the top-level origin and delegate access via Permissions Policy.
-            However, others, like the Storage Access API, explicitly describe a embeddee relationship and need to use the
-            embedded origin field.
-          </p>
-          <p class="note">
-            This assumes that passed in settings is from the embedded document.
+            Most permissions will want to set the permission grant on the top-level origin and delegate access via Permissions Policy.
+            However, others, like the Storage Access API, explicitly describe an embeddee relationship and could set a different granted origin.
           </p>
         </ol>
         </p>
@@ -356,11 +354,15 @@
         To <dfn class="export">compare [=permission store keys=]</dfn> |key1| and |key2|, run these steps:
         <ol class="algorithm">
           <li>
+            If |key1|'s [=permission store key/top-level origin=] is not [=same origin=] with |key2|'s [=permission store key/top-level origin=], return false.
+          </li>
+          <li>
+            If |key1|'s [=permission store key/granted origin=] is not [=same origin=] with |key2|'s [=permission store key/granted origin=], return false.
+          </li>
+          <li>
+            Return true.
           </li>
         </ol>
-        <p class="issue">
-        Do we have to define this? If we can compare origins we can probably implicitly compare a tuple of origins?
-        </p>
         </p>
 
         </p>

--- a/index.html
+++ b/index.html
@@ -608,7 +608,7 @@
         </dt>
         <dd>
           <p>
-            Takes two [=permission keys=] and returns a boolean that shows whether the two keys are equal.
+            Takes two [=permission keys=] and returns a [=boolean=] that shows whether the two keys are equal.
             If unspecified, this defaults to the <a>default permission key comparison algorithm</a>.
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
           The user agent MAY maintain additional permission stores with [=implementation-defined=] scope and eviction rules. Which permission store is adressed in a given moment is [=implementation-defined=].
           <aside class="note">
             This is intended to allow a user agent to experiment with user-friendly permission concepts such as per-tab grants.
-          </p>
+          </aside>
         </p>
         <p>
           A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of [=powerful feature/name=] <dfn>name</dfn>, [=permission store key=] <dfn>key</dfn>, {{PermissionDescriptor}} <dfn>descriptor</dfn>, and [=permission/state=] <dfn>state</dfn>.

--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
           Permission Store
         </h3>
         <p>
-        The user agent maintains a single <dfn class="export">global permission store</dfn> which is a list of [=permission store entries=].
+        The user agent maintains a single <dfn class="export">permission store</dfn> which is a [=/list=] of [=permission store entries=].
         The user agent removes [=entries=] from the list when their respective [=permission=]'s [=permission/lifetime=] has expired.
         </p>
         <p class="issue">
@@ -330,13 +330,13 @@
         </p>
 
         <p>
-        To <dfn class="export">generate a permission store key</dfn> `key` given [=environment settings object=] |settings|, run these steps:
+        To <dfn class="export">generate a permission store key</dfn> given [=environment settings object=] |settings|, run these steps:
         <ol class="algorithm">
           <li>
             Let |top-level origin| be |settings|' [=environment/top-level origin=].
           </li>
           <li>
-            Return (|top-level origin|, null)
+            Return (|top-level origin|, null).
           </li>
           <p class="issue">
           How do we ensure that other specs can override this? Should we add all key deviations as new steps to this algorithm or have a different override mechanism?

--- a/index.html
+++ b/index.html
@@ -290,79 +290,79 @@
         </p>
         <p>
           The user agent MAY maintain additional permission stores with [=implementation-defined=] scope and eviction rules. Which permission store is adressed in a given moment is [=implementation-defined=].
-          <p class="note">
+          <aside class="note">
             This is intended to allow a user agent to experiment with user-friendly permission concepts such as per-tab grants.
           </p>
         </p>
         <p>
-        A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of [=powerful feature/name=] <dfn>name</dfn>, [=permission store key=] <dfn>key</dfn>, {{PermissionDescriptor}} <dfn>descriptor</dfn>, and [=permission/state=] <dfn>state</dfn>.
+          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of [=powerful feature/name=] <dfn>name</dfn>, [=permission store key=] <dfn>key</dfn>, {{PermissionDescriptor}} <dfn>descriptor</dfn>, and [=permission/state=] <dfn>state</dfn>.
         </p>
         <p>
-        To <dfn class="export">get a permission store entry</dfn> from the user agent's permission store given a |name|, [=permission store key=] key and descriptor, run these steps:
-        <ol class="algorithm">
-          <li>
-          If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor|, return that entry.
-          </li>
-          <li>
-          Return null.
-          </li>
-        </ol>
+          To <dfn class="export">get a permission store entry</dfn> from the user agent's permission store given a |name|, [=permission store key=] key and descriptor, run these steps:
+          <ol class="algorithm">
+            <li>
+              If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor|, return that entry.
+            </li>
+            <li>
+              Return null.
+            </li>
+          </ol>
         </p>
         <p>
-        To <dfn class="export">set a permission store entry</dfn> in the user agent's permission store given a [=powerful feature/name=] |name|, a [=permission store key=] |key|, a {{PermissionDescriptor}} |descriptor|, and a [=permission/state=] |state|, run these steps:
-        <ol class="algorithm">
-          <li>
-            Let |newEntry| be a new [=permission store entry=] with the [=name=] |name|, [=key=] |key|, [=descriptor=] |descriptor|, and [=state=] |state|.
-          </li>
-          <li>
-            If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, the [=key=] |key| and the [=descriptor=] |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.
-          </li>
-          <li>
-            [=list/append=] |newEntry| to the permission store.
-          </li>
-        </ol>
+          To <dfn class="export">set a permission store entry</dfn> in the user agent's permission store given a [=powerful feature/name=] |name|, a [=permission store key=] |key|, a {{PermissionDescriptor}} |descriptor|, and a [=permission/state=] |state|, run these steps:
+          <ol class="algorithm">
+            <li>
+              Let |newEntry| be a new [=permission store entry=] with the [=name=] |name|, [=key=] |key|, [=descriptor=] |descriptor|, and [=state=] |state|.
+            </li>
+            <li>
+              If the permission store [=list/contains=] an [=entry=] with the [=name=] |name|, the [=key=] |key| and the [=descriptor=] |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.
+            </li>
+            <li>
+              [=list/append=] |newEntry| to the permission store.
+            </li>
+          </ol>
         </p>
         <p>
-        To <dfn class="export">remove a permission store entry</dfn> from the permission store given a name, key and descriptor, run these steps:
-        <ol class="algorithm">
-          <li>
-          [=list/Remove=] the [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor| from the permission store.
-          </li>
-        </ol>
+          To <dfn class="export">remove a permission store entry</dfn> from the permission store given a name, key and descriptor, run these steps:
+          <ol class="algorithm">
+            <li>
+            [=list/Remove=] the [=entry=] with the [=name=] |name|, [=key=] |key| and [=descriptor=] |descriptor| from the permission store.
+            </li>
+          </ol>
         </p>
         <p>
-        A <dfn class="export">permission store key</dfn> is a [=tuple=] of ([=origin=] <dfn data-dfn-for="permission store key">top-level origin</dfn>, [=origin=] <dfn data-dfn-for="permission store key">granted origin</dfn>).
+          A <dfn class="export">permission store key</dfn> is a [=tuple=] of ([=origin=] <dfn data-dfn-for="permission store key">top-level origin</dfn>, [=origin=] <dfn data-dfn-for="permission store key">granted origin</dfn>).
         </p>
 
         <p>
-        To <dfn class="export">generate a permission store key</dfn> given [=environment settings object=] |settings|, run these steps:
-        <ol class="algorithm">
-          <li>
-            Let |topLevelOrigin| be |settings|' [=environment/top-level origin=].
-          </li>
-          <li>
-            Return (|topLevelOrigin|, |topLevelOrigin|).
-          </li>
-          <p class="note">
+          To <dfn class="export">generate a permission store key</dfn> given [=environment settings object=] |settings|, run these steps:
+          <ol class="algorithm">
+            <li>
+              Let |topLevelOrigin| be |settings|' [=environment/top-level origin=].
+            </li>
+            <li>
+              Return (|topLevelOrigin|, |topLevelOrigin|).
+            </li>
+          </ol>
+          <aside class="note">
             Most permissions will want to set the permission grant on the top-level origin and delegate access via Permissions Policy.
             However, others, like the Storage Access API, explicitly describe an embeddee relationship and could set a different granted origin.
-          </p>
-        </ol>
+          </aside>
         </p>
 
         <p>
-        To <dfn class="export">compare [=permission store keys=]</dfn> |key1| and |key2|, run these steps:
-        <ol class="algorithm">
-          <li>
-            If |key1|'s [=permission store key/top-level origin=] is not [=same origin=] with |key2|'s [=permission store key/top-level origin=], return false.
-          </li>
-          <li>
-            If |key1|'s [=permission store key/granted origin=] is not [=same origin=] with |key2|'s [=permission store key/granted origin=], return false.
-          </li>
-          <li>
-            Return true.
-          </li>
-        </ol>
+          To <dfn class="export">compare [=permission store keys=]</dfn> |key1| and |key2|, run these steps:
+          <ol class="algorithm">
+            <li>
+              If |key1|'s [=permission store key/top-level origin=] is not [=same origin=] with |key2|'s [=permission store key/top-level origin=], return false.
+            </li>
+            <li>
+              If |key1|'s [=permission store key/granted origin=] is not [=same origin=] with |key2|'s [=permission store key/granted origin=], return false.
+            </li>
+            <li>
+              Return true.
+            </li>
+          </ol>
         </p>
 
         </p>

--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@
             </li>
           </ol>
           <aside class="note" title="Permission Delegation">
-            Most powerful features grant permission to the top-level origin and delegate access to the requesting document via Permissions Policy.
+            Most powerful features grant permission to the top-level origin and delegate access to the requesting document via [[[webappsec-permissions-policy]]].
             This is known as permission delegation.
           </aside>
         </dd>

--- a/index.html
+++ b/index.html
@@ -283,13 +283,13 @@
           Permission Store
         </h3>
         <p>
-          The user agent maintains a single <dfn class="export">permission store</dfn> which is a [=/list=] of [=permission store entries=].
+          The user agent maintains a single <dfn class="export">permission store</dfn> which is a [=/list=] of [=permission store entries=]. Each particular [=entry=] denoted by its [=permission store entry/descriptor=] and [=permission store entry/key=] can only appear at most once in this list.
         </p>
         <p>
           The user agent MAY remove [=entries=] from the [=permission store=] when their respective [=permission=]'s [=permission/lifetime=] has expired.
         </p>
         <p>
-          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, an instance <dfn class="export" data-dfn-for="permission store entry">key</dfn> of the [=permission key type=] of the feature named by [=permission store entry/descriptor=].name, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
+          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, an instance <dfn class="export" data-dfn-for="permission store entry">key</dfn> of the [=powerful feature/permission key type=] of the feature named by [=permission store entry/descriptor=].name, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
         </p>
         <p>
         To <dfn class="export">get a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor| and [=permission key=] |key|, run these steps:
@@ -340,11 +340,9 @@
               If |key1| is not of |descriptor|'s [=powerful feature/permission key type=] or |key2| is not of |descriptor|'s [=powerful feature/permission key type=], return false.
             </li>
             <li>
-              Return the result of running |descriptor|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission key comparison algorithm=], passing |key1| and |key2|.
+              Return the result of running the [=powerful feature/permission key comparison algorithm=] for the feature named by |descriptor|'s {{PermissionDescriptor/name}}, passing |key1| and |key2|.
             </li>
           </ol>
-        </p>
-
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
           A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, an instance <dfn class="export" data-dfn-for="permission store entry">key</dfn> of the [=powerful feature/permission key type=] of the feature named by [=permission store entry/descriptor=].name, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
         </p>
         <p>
-        To <dfn class="export">get a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor| and [=permission key=] |key|, run these steps:
+        To <dfn class="export">get a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor| and [=permission key=] |key|:
           <ol class="algorithm">
             <li>
               If the user agent's [=permission store=] [=list/contains=] an [=entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, return that entry.

--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@
           To <dfn class="export">set a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor|, a [=permission key=] |key|, and a [=permission/state=] |state|, run these steps:
           <ol class="algorithm">
             <li>
-              Let |newEntry| be a new [=permission store entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, and whose [=permission store entry/state=] is |state|.
+              Let |newEntry| be a new [=permission store entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] is |key|, and whose [=permission store entry/state=] is |state|.
             </li>
             <li>
               If the user agent's [=permission store=] [=list/contains=] an [=entry=] whose [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store entry/key=] [=permission key/is equal to=] |key| given |descriptor|, [=list/replace=] that entry with |newEntry| and abort these steps.

--- a/index.html
+++ b/index.html
@@ -325,16 +325,20 @@
           </ol>
         </p>
         <p>
-          A <dfn class="export">permission key</dfn> has the type returned by the feature's [=powerful feature/permission key generation algorithm=].
+          A <dfn class="export">permission key</dfn> has its type defined by a feature's [=powerful feature/permission key type=].
           <aside class="note">
-            Powerful features may override the key generation algorithm to specify a custom permission key.
-            This is useful for features that want to restrict permissions based on additional context,
-            such as double-keying on both the embedded origin and the top-level origin.
+            The permission key defines the scope of a permission grant, which is usually per-origin.
+            Powerful features may override the [=powerful feature/permission key type=] to specify a custom permission key.
+            This is useful for features that want to change the granularity of permissions based on additional context,
+            such as double-keying on both an embedded origin and a top-level origin.
           </aside>
         </p>
         <p>
           To determine whether a [=permission key=] |key1| <dfn class="export" for="permission key">is equal to</dfn> a [=permission key=] |key2|, given a {{PermissionDescriptor}} |descriptor|, run the following steps:
           <ol class="algorithm">
+            <li>
+              If |key1| is not of |descriptor|'s [=powerful feature/permission key type=] or |key2| is not of |descriptor|'s [=powerful feature/permission key type=], return false.
+            </li>
             <li>
               Return the result of running |descriptor|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission key comparison algorithm=], passing |key1| and |key2|.
             </li>
@@ -567,6 +571,16 @@
           </ol>
         </dd>
         <dt>
+          A <dfn data-dfn-for="powerful feature" class="export">permission key type</dfn>:
+        </dt>
+        <dd>
+          <p>
+            The type of [=permission key=] used by the feature. Defaults to [=origin=].
+            A feature that specifies a custom [=powerful feature/permission key type=] MUST also specify a
+            [=powerful feature/permission key generation algorithm=].
+          </p>
+        </dd>
+        <dt>
           A <dfn data-dfn-for="powerful feature" class="export">permission key generation algorithm</dfn>:
         </dt>
         <dd>
@@ -603,9 +617,6 @@
             given [=permission keys=] |key1| and |key2|, runs the following steps:
           </p>
           <ol class="algorithm">
-            <li>
-              If |key1| is not an [=origin=] or |key2| is not an [=origin=] return false.
-            </li>
             <li>
               If |key1| is not [=same origin=] with |key2| return false.
             </li>
@@ -745,7 +756,7 @@
           </li>
           <li>Let |entry| be the result of [=get a permission store entry|getting a permission store entry=] with |descriptor| and |key|.
           </li>
-          <li>If |entry| is not null, return a {{PermissionState}} enum value from |entry|'s [=permission store entry/state=] and |entry|'s [=permission store entry/descriptor=]'s {{PermissionDescriptor/name}}.
+          <li>If |entry| is not null, return a {{PermissionState}} enum value from |entry|'s [=permission store entry/state=].
           </li>
           <li>Return the {{PermissionState}} enum value that represents the permission state of
           |feature|, taking into account any [=powerful feature/permission state constraints=] for
@@ -865,15 +876,10 @@
         </p>
         <ol class="algorithm">
           <li>
-            <a>Queue a global task</a> on the [=user interaction task source=] to:.
-            <ol>
-              <li>
-                Run |descriptor|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission revocation algorithm=].
-              </li>
-              <li>
-                [=Remove a permission store entry=] with |descriptor| and |key|.
-              </li>
-            </ol>
+            Run |descriptor|'s {{PermissionDescriptor/name}}'s [=powerful feature/permission revocation algorithm=].
+          </li>
+          <li>
+            [=Remove a permission store entry=] with |descriptor| and |key|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -334,7 +334,7 @@
           </aside>
         </p>
         <p>
-          To determine whether a [=permission key=] |key1| <dfn class="export" for="permission key">is equal to</dfn> a [=permission key=] |key2|, given a {{PermissionDescriptor}} |descriptor|, run the following steps:
+          To determine whether a [=permission key=] |key1| <dfn class="export" data-dfn-for="permission key">is equal to</dfn> a [=permission key=] |key2|, given a {{PermissionDescriptor}} |descriptor|, run the following steps:
           <ol class="algorithm">
             <li>
               If |key1| is not of |descriptor|'s [=powerful feature/permission key type=] or |key2| is not of |descriptor|'s [=powerful feature/permission key type=], return false.

--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
           The user agent MAY remove [=entries=] from the [=permission store=] when their respective [=permission=]'s [=permission/lifetime=] has expired.
         </p>
         <p>
-          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, [=permission key=] <dfn class="export" data-dfn-for="permission store entry">key</dfn>, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
+          A <dfn class="export" data-local-lt="entry">permission store entry</dfn> is a [=tuple=] of {{PermissionDescriptor}} <dfn class="export" data-dfn-for="permission store entry">descriptor</dfn>, an instance <dfn class="export" data-dfn-for="permission store entry">key</dfn> of the [=permission key type=] of the feature named by [=permission store entry/descriptor=].name, and [=permission/state=] <dfn class="export" data-dfn-for="permission store entry">state</dfn>.
         </p>
         <p>
         To <dfn class="export">get a permission store entry</dfn> given a {{PermissionDescriptor}} |descriptor| and [=permission key=] |key|, run these steps:

--- a/index.html
+++ b/index.html
@@ -331,38 +331,12 @@
           </ol>
         </p>
         <p>
-          A <dfn class="export">permission store key</dfn> is a [=tuple=] of ([=origin=] <dfn data-dfn-for="permission store key">top-level origin</dfn>, [=origin=] <dfn data-dfn-for="permission store key">granted origin</dfn>).
-        </p>
-
-        <p>
-          To <dfn class="export">generate a permission store key</dfn> given [=environment settings object=] |settings|, run these steps:
-          <ol class="algorithm">
-            <li>
-              Let |topLevelOrigin| be |settings|' [=environment/top-level origin=].
-            </li>
-            <li>
-              Return (|topLevelOrigin|, |topLevelOrigin|).
-            </li>
-          </ol>
+          A <dfn class="export">permission store key</dfn> has the type returned by the feature's [=powerful feature/permission key generation algorithm=].
           <aside class="note">
-            Most permissions will want to set the permission grant on the top-level origin and delegate access via Permissions Policy.
-            However, others, like the Storage Access API, explicitly describe an embeddee relationship and could set a different granted origin.
+            Powerful features may override the key generation algorithm to specify a custom permission store key.
+            This is useful for features that want to restrict permissions based on additional context,
+            such as double-keying on both the embedded origin and the top-level origin.
           </aside>
-        </p>
-
-        <p>
-          To <dfn class="export">compare [=permission store keys=]</dfn> |key1| and |key2|, run these steps:
-          <ol class="algorithm">
-            <li>
-              If |key1|'s [=permission store key/top-level origin=] is not [=same origin=] with |key2|'s [=permission store key/top-level origin=], return false.
-            </li>
-            <li>
-              If |key1|'s [=permission store key/granted origin=] is not [=same origin=] with |key2|'s [=permission store key/granted origin=], return false.
-            </li>
-            <li>
-              Return true.
-            </li>
-          </ol>
         </p>
 
         </p>
@@ -591,6 +565,51 @@
           </ol>
         </dd>
         <dt>
+          A <dfn data-dfn-for="powerful feature" class="export">permission key generation algorithm</dfn>:
+        </dt>
+        <dd>
+          <p>
+            Takes an [=environment settings object=], and returns a new [=permission store key=].
+            If unspecified, this defaults to the <a>default permission key generation algorithm</a>.
+            A feature that specifies a custom [=powerful feature/permission key generation algorithm=] MUST also specify a
+            [=powerful feature/permission key comparison algorithm=].
+          </p>
+          <p>
+            The <dfn data-export="">default permission key generation algorithm</dfn>,
+            given an [=environment settings object=] |settings|, runs the following steps:
+          </p>
+          <ol class="algorithm">
+            <li>
+              Return |settings|' [=environment/top-level origin=].
+            </li>
+          </ol>
+          <aside class="note" title="Permission Delegation">
+            Most powerful features grant permission to the top-level origin and delegate access to the requesting document via Permissions Policy.
+            This is called Permission Delegation.
+          </aside>
+        </dd>
+        <dt>
+          A <dfn data-dfn-for="powerful feature" class="export">permission key comparison algorithm</dfn>:
+        </dt>
+        <dd>
+          <p>
+            Takes two [=permission store keys=] and returns a boolean that shows whether the two keys are equal.
+            If unspecified, this defaults to the <a>default permission key comparison algorithm</a>.
+          </p>
+          <p>
+            The <dfn data-export="">default permission key comparison algorithm</dfn>,
+            given [=permission store keys=] |key1| and |key2| (both [=origins=]), runs the following steps:
+          </p>
+          <ol class="algorithm">
+            <li>
+              If |key1| is not [=same origin=] with |key2| return false.
+            </li>
+            <li>
+              Return true.
+            </li>
+          </ol>
+        </dd>
+        <dt>
           A <dfn data-dfn-for="powerful feature" class="export">permission revocation
           algorithm</dfn>:
         </dt>
@@ -717,7 +736,7 @@
               </li>
             </ol>
           </li>
-          <li>Let |key| be the result of [=generate a permission store key|generating a permission store key=] with |settings|.
+          <li>Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission store key=] with |settings|.
           </li>
           <li>Let |entry| be the result of [=get a permission store entry|getting a permission store entry=] with |feature|, |descriptor| and |key|.
           </li>
@@ -764,7 +783,7 @@
             </p>
           </li>
           <li>
-            Let |key| be the result of [=generate a permission store key|generating a permission store key=] with the [=current settings object=].
+            Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission store key=] with the [=current settings object=].
           </li>
           <li>
             [=Queue a task=] on the [=current settings object=]'s [=environment settings
@@ -843,7 +862,7 @@
             feature's [=powerful feature/permission revocation algorithm=].
           </li>
           <li>
-            Let |key| be the result of [=generate a permission store key|generating a permission store key=] with the Realm's [=Realm/settings object=].
+            Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission store key=] with the Realm's [=Realm/settings object=].
           </li>
           <li>
             TODO: How do I get the feature descriptor to remove the feature here?

--- a/index.html
+++ b/index.html
@@ -752,7 +752,7 @@
               </li>
             </ol>
           </li>
-          <li>Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission key=] with |settings|.
+          <li>Let |key| be the result of [=powerful feature/permission key generation algorithm|generating a permission key=] for |descriptor| with |settings|.
           </li>
           <li>Let |entry| be the result of [=get a permission store entry|getting a permission store entry=] with |descriptor| and |key|.
           </li>


### PR DESCRIPTION
This is a draft attempt at defining a permission store with a couple of questions still to be figured out, some of which are also marked as issues inline. Some high-level thoughts:

- I've so far declared a single global permission store to be maintained by UAs, is that what we were shooting for?
- We should still allow for UAs to have more flexibility in storing smaller-scoped or shorter-lived permissions, e.g. for a single tab. It feels like this needs to be a non-normative note as attempting to specify that might go against the idea that it can be flexible.
- This ignores a lot of details around how we need to cross the process boundary to access permissions, though I've tried to make setting (and removing) permissions an async step.
- As discussed with Anne before, there's the question of whether individual permissions should define their own key generation algorithms or whether they should get if-statements in the central key generation algorithm.

Requesting an early look/advice from @annevk and @jyasskin :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/permissions/pull/390.html" title="Last updated on Dec 9, 2022, 9:08 AM UTC (66434eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/390/91ea715...johannhof:66434eb.html" title="Last updated on Dec 9, 2022, 9:08 AM UTC (66434eb)">Diff</a>