### PR TITLE
Editorial: fix PermissionDescriptor name check in query()

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,8 +801,14 @@
                 </li>
               </ol>
             </li>
-            <li>If |permissionDesc|'s {{PermissionDescriptor/name}} member is not supported, return
-            [=a promise rejected with=] a {{TypeError}}.
+            <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to an IDL
+            value</a> of type {{PermissionDescriptor}}.
+            </li>
+            <li>If the conversion [=exception/throws=] an [=exception=], return <a>a promise
+            rejected with</a> that exception.
+            </li>
+            <li>If |rootDesc|'s {{PermissionDescriptor/name}} member is not supported, return [=a
+            promise rejected with=] a {{TypeError}}.
               <aside class="note" title="Why is this not an enum?">
                 <p>
                   This is deliberately designed to work the same as WebIDL's [=enumeration=]
@@ -813,12 +819,6 @@
                   features from the [[[permissions-registry]]] they wish to support.
                 </p>
               </aside>
-            </li>
-            <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to an IDL
-            value</a> of type {{PermissionDescriptor}}.
-            </li>
-            <li>If the conversion [=exception/throws=] an [=exception=], return <a>a promise
-            rejected with</a> that exception.
             </li>
             <li>Let |typedDescriptor| be the object |permissionDesc| refers to, <a>converted to an
             IDL value</a> of |rootDesc|'s {{PermissionDescriptor/name}}'s [=powerful

--- a/index.html
+++ b/index.html
@@ -807,7 +807,7 @@
             <li>If the conversion [=exception/throws=] an [=exception=], return <a>a promise
             rejected with</a> that exception.
             </li>
-            <li>If |rootDesc|'s {{PermissionDescriptor/name}} member is not supported, return [=a
+            <li>If |rootDesc|["{{PermissionDescriptor/name}}"] is not supported, return [=a
             promise rejected with=] a {{TypeError}}.
               <aside class="note" title="Why is this not an enum?">
                 <p>


### PR DESCRIPTION
closes #403


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/pull/404.html" title="Last updated on Dec 9, 2022, 1:30 AM UTC (ca78a31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/404/5fd60ef...ca78a31.html" title="Last updated on Dec 9, 2022, 1:30 AM UTC (ca78a31)">Diff</a>