### PR TITLE
Export definition of Set Permission extension command

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,7 +1217,7 @@
           </tbody>
         </table>
         <p>
-          The <dfn>Set Permission</dfn> <a>extension command</a> simulates user modification of a
+          The <dfn class="export" data-dfn-for="extension commands">Set Permission</dfn> <a>extension command</a> simulates user modification of a
           {{PermissionDescriptor}}'s <a>permission state</a>.
         </p>
         <p>
@@ -1275,7 +1275,7 @@
         </ol>
         <aside class="example" title="Setting a permission via WebDriver">
           <p>
-            To [=set permission=] for `{name: "midi", sysex: true}` of the [=current settings
+            To [=extension commands/set permission=] for `{name: "midi", sysex: true}` of the [=current settings
             object=] of the <a>session</a> with ID 23 to "`granted`", the local end would POST to
             `/session/23/permissions` with the body:
           </p>


### PR DESCRIPTION
Used e.g. by https://w3c.github.io/mediacapture-automation/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/permissions/pull/408.html" title="Last updated on Dec 15, 2022, 5:52 AM UTC (68b8b9d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/408/9aaca68...dontcallmedom:68b8b9d.html" title="Last updated on Dec 15, 2022, 5:52 AM UTC (68b8b9d)">Diff</a>