### PR TITLE
replace cdn.w3.org by www.w3.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,14 +174,14 @@ img.caniuse-browser{filter:drop-shadow(0 0 .1cm #666)}
 .mdn tr::before{content:"";display:table-cell;width:1.5em;height:1.5em;background:no-repeat center center/contain;font-size:.75em}
 .mdn .no,.mdn .unknown{color:#ccc;filter:grayscale(100%)}
 .mdn .no::before,.mdn .unknown::before{opacity:.5}
-.mdn .chrome::before,.mdn .chrome_android::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/chrome/chrome.svg)}
-.mdn .edge::before,.mdn .edge_mobile::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/edge/edge.svg)}
-.mdn .firefox::before,.mdn .firefox_android::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/firefox/firefox.svg)}
-.mdn .opera::before,.mdn .opera_android::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/opera/opera.svg)}
-.mdn .safari::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/safari/safari.svg)}
-.mdn .safari_ios::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/safari-ios/safari-ios.svg)}
-.mdn .samsunginternet_android::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/samsung-internet/samsung-internet.svg)}
-.mdn .webview_android::before{background-image:url(https://cdn.w3.org/assets/logos/browser-logos/android-webview/android-webview.png)}
+.mdn .chrome::before,.mdn .chrome_android::before{background-image:url(https://www.w3.org/assets/logos/browser-logos/chrome/chrome.svg)}
+.mdn .edge::before,.mdn .edge_mobile::before{background-image:url(https://www.w3.org/assets/logos/browser-logos/edge/edge.svg)}
+.mdn .firefox::before,.mdn .firefox_android::before{background-image:url(https://www.w3.org/assets/logos/browser-logos/firefox/firefox.svg)}
+.mdn .opera::before,.mdn .opera_android::before{background-image:url(https://www.w3.org/assets/logos/browser-logos/opera/opera.svg)}
+.mdn .safari::before{background-image:url(https://www.w3.org/assets/logos/browser-logos/safari/safari.svg)}
+.mdn .safari_ios::before{background-image:url(https://www.w3.org/assets/logos/browser-logos/safari-ios/safari-ios.svg)}
+.mdn .samsunginternet_android::before{background-image:url(https://wwww.w3.org/assets/logos/browser-logos/samsung-internet/samsung-internet.svg)}
+.mdn .webview_android::before{background-image:url(https://www.w3.org/assets/logos/browser-logos/android-webview/android-webview.png)}
 </style>
 <meta name="description" content="This specification defines common infrastructure that other specifications can use to
         interact with browser permissions. These permissions represent a user's choice to allow or
@@ -315,26 +315,26 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       <dt class="caniuse-title">Browser support:</dt><dd class="caniuse-stats">
       <div class="caniuse-group">
           <div class="caniuse-browsers"><div class="caniuse-cell y" title="Supported by default since Chrome version 43." aria-label="permissions-api is supported by default since Chrome version 43 on desktop.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/chrome/chrome.svg" alt="Chrome logo"><span class="browser-version">43</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/chrome/chrome.svg" alt="Chrome logo"><span class="browser-version">43</span>
       </div><div class="caniuse-cell y" title="Supported by default since Edge version 79." aria-label="permissions-api is supported by default since Edge version 79 on desktop.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/edge/edge.svg" alt="Edge logo"><span class="browser-version">79</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/edge/edge.svg" alt="Edge logo"><span class="browser-version">79</span>
       </div><div class="caniuse-cell y" title="Supported by default since Firefox version 46." aria-label="permissions-api is supported by default since Firefox version 46 on desktop.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/firefox/firefox.svg" alt="Firefox logo"><span class="browser-version">46</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/firefox/firefox.svg" alt="Firefox logo"><span class="browser-version">46</span>
       </div><div class="caniuse-cell y" title="Supported by default since Safari version 16.0." aria-label="permissions-api is supported by default since Safari version 16.0 on desktop.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/safari/safari.svg" alt="Safari logo"><span class="browser-version">16.0</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/safari/safari.svg" alt="Safari logo"><span class="browser-version">16.0</span>
       </div></div>
           <div class="caniuse-type"><span>desktop</span></div>
         </div><div class="caniuse-group">
           <div class="caniuse-browsers"><div class="caniuse-cell y" title="Supported by default since Android Chrome version 108." aria-label="permissions-api is supported by default since Android Chrome version 108 on mobile.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/chrome/chrome.svg" alt="Android Chrome logo"><span class="browser-version">108</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/chrome/chrome.svg" alt="Android Chrome logo"><span class="browser-version">108</span>
       </div><div class="caniuse-cell y" title="Supported by default since Android Firefox version 107." aria-label="permissions-api is supported by default since Android Firefox version 107 on mobile.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/firefox/firefox.svg" alt="Android Firefox logo"><span class="browser-version">107</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/firefox/firefox.svg" alt="Android Firefox logo"><span class="browser-version">107</span>
       </div><div class="caniuse-cell y" title="Supported by default since Android UC version 13.4." aria-label="permissions-api is supported by default since Android UC version 13.4 on mobile.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/uc/uc.svg" alt="Android UC logo"><span class="browser-version">13.4</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/uc/uc.svg" alt="Android UC logo"><span class="browser-version">13.4</span>
       </div><div class="caniuse-cell y" title="Supported by default since iOS Safari version 16.0." aria-label="permissions-api is supported by default since iOS Safari version 16.0 on mobile.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/safari-ios/safari-ios.svg" alt="iOS Safari logo"><span class="browser-version">16.0</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/safari-ios/safari-ios.svg" alt="iOS Safari logo"><span class="browser-version">16.0</span>
       </div><div class="caniuse-cell y" title="Supported by default since Samsung Internet version 4." aria-label="permissions-api is supported by default since Samsung Internet version 4 on mobile.">
-        <img class="caniuse-browser" width="20" height="20" src="https://cdn.w3.org/assets/logos/browser-logos/samsung-internet/samsung-internet.svg" alt="Samsung Internet logo"><span class="browser-version">4</span>
+        <img class="caniuse-browser" width="20" height="20" src="https://www.w3.org/assets/logos/browser-logos/samsung-internet/samsung-internet.svg" alt="Samsung Internet logo"><span class="browser-version">4</span>
       </div></div>
           <div class="caniuse-type"><span>mobile</span></div>
         </div><a class="caniuse-cell" href="https://caniuse.com/permissions-api">More info</a>


### PR DESCRIPTION
Simple PR to replace cdn.w3.org by www.w3.org (cdn.w3.org is going down) on the official ED.
[Respec has already been fixed](https://github.com/w3c/respec/pull/4442).