### PR TITLE
Add missing semicolon to WebIDL example

### DIFF
--- a/index.html
+++ b/index.html
@@ -429,7 +429,7 @@
               dictionary SensesPermissionDescriptor : PermissionDescriptor {
                 boolean canSmell = false;
                 boolean canTaste = false;
-              }
+              };
             </pre>
             <p>
               Which would then be queried via the API in the following way:


### PR DESCRIPTION
Fixes #415

