### PR TITLE
Inform users when a UA administrator overrides their permission choices.

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,7 +234,8 @@
             <dfn class="export" data-local-lt="grant" data-dfn-for="permission">Granted</dfn>:
           </dt>
           <dd>
-            The user, or the user agent on the user's behalf, has given [=express permission=] to
+            The user, or the user agent or its [=administrator=] on the user's behalf,
+            has given [=express permission=] to
             use a [=powerful feature=]. The caller will can use the feature possibly without having
             the [=user agent=] asking the user's permission.
           </dd>
@@ -242,7 +243,8 @@
             <dfn class="export" data-dfn-for="permission">Denied</dfn>:
           </dt>
           <dd>
-            The user, or the user agent on the user's behalf, has denied access to this [=powerful
+            The user, or the user agent or its [=administrator=] on the user's behalf,
+            has denied access to this [=powerful
             feature=]. The caller will can't use the feature.
           </dd>
         </dl>
@@ -550,9 +552,11 @@
             |settings|, returning |previousResult|, and the user agent has not received <a>new
             information about the user's intent</a> since that invocation, return |previousResult|.
             </li>
-            <li>Return the instance of |name|'s [=powerful feature/extra permission data type=]
-            that matches the UA's impression of the user's intent, taking into account any
-            [=powerful feature/extra permission data constraints=] for |name|.
+            <li>Return the instance of |name|'s [=powerful feature/extra permission data type=] that
+            matches the UA's impression of the user's intent, combined with any configuration from
+            the user agent's [=administrator=], taking into account any [=powerful feature/extra
+            permission data constraints=] for |name|. If [=administrator=] configuration affected the
+            result, the [=user agent=] must inform the user.
             </li>
           </ol>
           <p>
@@ -817,18 +821,31 @@
           <li>If <var>current state</var> is not {{PermissionState/"prompt"}}, return <var>current
           state</var> and abort these steps.
           </li>
-          <li>Ask the user for <a>express permission</a> for the calling algorithm to use the
-          <a>powerful feature</a> described by |descriptor|.
+          <li>If the [=user agent=] has an [=administrator=] who has configured the [=user agent=]
+          to grant or deny permission for the calling algorithm to use the <a>powerful feature</a>
+          described by |descriptor|:
+          <ol>
+            <li>Set |current state| to {{PermissionState/"granted"}} if the [=administrator=]
+            granted permission; otherwise to {{PermissionState/"denied"}}.</li>
+            <li>Inform the user of the [=administrator=]'s configuration.</li>
+          </ol>
           </li>
-          <li>If the user gives [=express permission=] to use the powerful feature, set |current
-          state| to {{PermissionState/"granted"}}; otherwise to {{PermissionState/"denied"}}. The
-          user's interaction may provide <a>new information about the user's intent</a> for the
-          [=origin=].
-            <p class="note">
-              This is intentionally vague about the details of the permission UI and how the user
-              agent infers user intent. User agents should be able to explore lots of UI within
-              this framework.
-            </p>
+          <li>Otherwise:
+            <ol>
+              <li>Ask the user for <a>express permission</a> for the calling algorithm to use the
+              <a>powerful feature</a> described by |descriptor|.
+              </li>
+              <li>If the user gives [=express permission=] to use the powerful feature, set |current
+              state| to {{PermissionState/"granted"}}; otherwise to {{PermissionState/"denied"}}. The
+              user's interaction may provide <a>new information about the user's intent</a> for the
+              [=origin=].
+                <p class="note">
+                  This is intentionally vague about the details of the permission UI and how the user
+                  agent infers user intent. User agents should be able to explore lots of UI within
+                  this framework.
+                </p>
+              </li>
+            </ol>
           </li>
           <li>Let |key| be the result of [=powerful feature/permission key generation
           algorithm|generating a permission key=] with the [=current settings object=].
@@ -1307,6 +1324,12 @@
       <p>
         A user agent SHOULD provide a means for the user to review, update, and reset the
         [=permission=] [=permission/state=] of [=powerful features=] associated with an [=origin=].
+      </p>
+      <p>
+        Some [=user agents=] support <dfn data-lt="administrator">administrators</dfn> who can
+        override user choices about permissions, either to block permissions or to allow them on
+        certain sites. Overriding user choices in this way can be a privacy problem, so this
+        specification requires that the [=user agent=] inform users when it happens.
       </p>
     </section>
     <section id="security-considerations">


### PR DESCRIPTION
This is still somewhat exploratory, to see if this is a good way to explain how UAs should handle cases where their enterprise policies override user choices about permissions. It implements https://w3ctag.github.io/privacy-principles/#device-administrators for this spec, and the idea to try it out here came from the [Standardizing managed user agent behavior session at TPAC 2023](https://www.w3.org/events/meetings/d98c0762-eb0c-4cf6-85eb-fff31dedc9e9/).

@reillyeon, can you cc in whichever Chrome enterprise folks should pay attention? @timcappalli are you the right person to check this for Microsoft's enterprise system?

The following tasks have been completed:

 * [ ] Modified Web platform tests (link)

Implementation commitment:

 * [ ] WebKit (link to issue)
 * [ ] Blink (link to issue)
 * [ ] Gecko (link to issue)

