### PR TITLE
Introduce Browser Permissions for WebDriver BiDi

### DIFF
--- a/index.html
+++ b/index.html
@@ -1382,7 +1382,6 @@
                     permissions.SetPermissionParameters = {
                       descriptor: permissions.PermissionDescriptor,
                       state: permissions.PermissionState,
-                      ? context: browsingContext.BrowsingContext,
                       ? origin: text,
                     }
                   </pre>
@@ -1408,28 +1407,13 @@
    parameters|.
                 </li>
                 <li>
-                  Let |context id| be the value of the <code>context</code> field of
-   |command parameters|.
-                </li>
-                <li>
-                  If |context id| is not present, let |context| be the [=top-level browsing context=]
-   of |session|. Otherwise, let |context| be the result of [=trying=] to
-   [=get a browsing context=] with |context id|.
-                </li>
-                <li>
                   Let |permission name| be the value of the <code>name</code> field of
    |descriptor| representing {{PermissionDescriptor/name}}.
                 </li>
                 <li>
-                  <!-- TODO: Only convert to an IDL value only once. -->
-                  [=Convert to an IDL value=] (|descriptor|, |state|) of type {{PermissionSetParameters}}.
-   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
-                </li>
-                <li>
-                  Let |typedDescriptor| be the object |descriptor| refers to, <a>converted to an IDL
-                    value</a> of |permission name|'s [=powerful
-                    feature/permission descriptor type=]. If this throws an exception,
-                    return [=error=] with [=error code=] [=invalid argument=].
+                  Let |typedDescriptor| be the object |descriptor| refers to, [=converted to an IDL value=] (|descriptor|, |state|) of
+                  {{PermissionSetParameters}} |permission name|'s [=powerful feature/permission descriptor type=].
+                  If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
                 </li>
                 <li>
                   If |state| is an inappropriate [=permission state=] for any

--- a/index.html
+++ b/index.html
@@ -1277,7 +1277,7 @@
               </p>
             </li>
             <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
-            value</a> of `|rootDesc|.{{PermissionDescriptor/name}}`'s [=powerful
+            value</a> of |rootDesc|.{{PermissionDescriptor/name}}'s [=powerful
             feature/permission descriptor type=]. If this throws an exception, return a [=invalid
             argument=] [=error=].
             </li>

--- a/index.html
+++ b/index.html
@@ -1308,63 +1308,63 @@
         This document defines the following [=extension modules=] for the [[WebDriver-BiDi]] specification.
       </p>
       <section>
-        <h4 id="extension-module-browser">
-          The browser Module
+        <h4 id="extension-module-permissions">
+          The permissions Module
         </h4>
         <p>
-          The [=modules/browser=] module contains commands for
-          managing the remote end browser process.
+          The <dfn>permissions</dfn> module contains commands for
+          managing the remote end browser permissions.
         </p>
         <section>
-          <h5 id="extension-module-browser-definition">
+          <h5 id="extension-module-permissions-definition">
             Definition
           </h5>
           <p>
             [=remote end definition=]
           </p>
           <pre class="cddl remote-cddl">
-            BrowserCommand = (
-              browser.setPermission
+            PermissionsCommand = (
+              permissions.setPermission
             )
           </pre>
         </section>
         <section>
-          <h5 id="extension-module-browser-types">
+          <h5 id="extension-module-permissions-types">
             Types
           </h5>
           <section>
-            <h6 id="extension-module-type-browser-PermissionDescriptor">
-              The browser.PermissionDescriptor Type
+            <h6 id="extension-module-type-permissions-PermissionDescriptor">
+              The permissions.PermissionDescriptor Type
             </h6>
             <pre class="cddl local-cddl">
-              browser.PermissionDescriptor = {
+              permissions.PermissionDescriptor = {
                 type: "permissionDescriptor",
                 name: text,
               }
             </pre>
             <p>
-              The <code>browser.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
+              The <code>permissions.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
             </p>
           </section>
           <section>
-            <h6 id="extension-module-type-browser-PermissionState">
-              The browser.PermissionState Type
+            <h6 id="extension-module-type-permissions-PermissionState">
+              The permissions.PermissionState Type
             </h6>
             <pre class="cddl local-cddl">
-              browser.PermissionState = "granted" / "denied" / "prompt"
+              permissions.PermissionState = "granted" / "denied" / "prompt"
             </pre>
             <p>
-              The <code>browser.PermissionState</code> type represents a {{PermissionState}}.
+              The <code>permissions.PermissionState</code> type represents a {{PermissionState}}.
             </p>
           </section>
         </section>
         <section>
-          <h5 id="extension-module-browser-commands">
+          <h5 id="extension-module-permissions-commands">
             Commands
           </h5>
           <section>
-            <h6 id="extension-module-command-browser-setPermission">
-              The browser.setPermission Command
+            <h6 id="extension-module-command-permissions-setPermission">
+              The permissions.setPermission Command
             </h6>
             <p>
               The <dfn class="export" data-dfn-for="extension modules">Set Permission</dfn>
@@ -1375,14 +1375,14 @@
               <dt>Command Type</dt>
               <dd>
                 <pre class="cddl remote-cddl">
-                  browser.setPermission = (
-                    method: "browser.setPermission",
-                    params: browser.SetPermissionParameters
+                  permissions.setPermission = (
+                    method: "permissions.setPermission",
+                    params: permissions.SetPermissionParameters
                   )
 
-                  browser.SetPermissionParameters = {
-                    descriptor: browser.PermissionDescriptor,
-                    state: browser.PermissionState,
+                  permissions.SetPermissionParameters = {
+                    descriptor: permissions.PermissionDescriptor,
+                    state: permissions.PermissionState,
                     ? context: browsingContext.BrowsingContext,
                     ? origin: text,
                   }

--- a/index.html
+++ b/index.html
@@ -1371,8 +1371,8 @@
                 The permissions.setPermission Command
               </h6>
               <p>
-                The <dfn class="export" data-dfn-for="extension modules">Set Permission</dfn>
-                [=extension module=] simulates user modification of a {{PermissionDescriptor}}'s
+                The <dfn class="export">Set Permission</dfn>
+                [=command=] simulates user modification of a {{PermissionDescriptor}}'s
                 [=permission state=].
               </p>
               <dl>
@@ -1399,10 +1399,10 @@
              </dl>
              <ol algorithm="remote end steps for permissions.setPermission">
                <p>
-                TODO: Add user context to SetPermissionParameters.
+                TODO: Add user <code>context</code> to <code>SetPermissionParameters</code>.
                </p>
                <p>
-                TODO: Add origin.
+                TODO: Add <code>origin</code>.
                </p>
                <p>
                  The [=remote end steps=] with |session| and |command parameters| are:

--- a/index.html
+++ b/index.html
@@ -1177,14 +1177,14 @@
         permission=] or by some user agent policy.
       </p>
     </section>
-    <section data-cite="webdriver">
+    <section>
       <h2 id="automation">
         Automated testing
       </h2>
       <p>
         For the purposes of user-agent automation and application testing, this document defines
-        the following <a>extension commands</a> for the [[WebDriver]] specification. It is OPTIONAL
-        for a user agent to support <a>extension commands</a> commands.
+        extensions to the [[WebDriver]] and [[WebDriver-BiDi]] specifications.
+        It is OPTIONAL for a user agent to support them.
       </p>
       <pre class='idl'>
         dictionary PermissionSetParameters {
@@ -1192,104 +1192,290 @@
           required PermissionState state;
         };
       </pre>
-      <section>
-        <h3 id="set-permission-command">
-          Set Permission
+      <section data-cite="webdriver-bidi webdriver">
+        <h3 id="automation-webdriver-bidi">
+          Automated testing with [[WebDriver-BiDi]]
         </h3>
-        <table>
-          <tbody>
-            <tr>
-              <th>
-                HTTP Method
-              </th>
-              <th>
-                <a data-lt="extension command URI template">URI Template</a>
-              </th>
-            </tr>
-            <tr>
-              <td>
-                POST
-              </td>
-              <td>
-                /session/{session id}/permissions
-              </td>
-            </tr>
-          </tbody>
-        </table>
         <p>
-          The <dfn class="export" data-dfn-for="extension commands">Set Permission</dfn>
-          <a>extension command</a> simulates user modification of a {{PermissionDescriptor}}'s
-          <a>permission state</a>.
+          This document defines the following [=extension modules=] for the [[WebDriver-BiDi]] specification.
         </p>
-        <p>
-          The <a>remote end steps</a> are:
-        </p>
-        <ol>
-          <li>Let |parameters| be the |parameters| argument, <a>converted to an IDL value</a> of
-          type {{PermissionSetParameters}}. If this throws an exception, return an [=invalid
-          argument=] [=error=].
-          </li>
-          <li>Let |rootDesc| be |parameters|.{{PermissionSetParameters/descriptor}}.
-          </li>
-          <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
-          value</a> of <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s [=powerful
-          feature/permission descriptor type=]. If this throws an exception, return a [=invalid
-          argument=] [=error=].
-          </li>
-          <li>If |parameters|.{{PermissionSetParameters/state}} is an inappropriate <a>permission
-          state</a> for any implementation-defined reason, return a [=invalid argument=] [=error=].
-            <p class="note">
-              For example, <a>user agents</a> that define the "midi" <a>powerful feature</a> as
-              "always on" may choose to reject a command to set the <a>permission state</a> to
-              {{PermissionState/"denied"}} at this step.
-            </p>
-          </li>
-          <li>Let |settings| be the [=current settings object=].
-          </li>
-          <li>Let |targets| be a <a>list</a> containing all <a>environment settings objects</a>
-          whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
-          the [=environment settings object/origin=] of |settings|.
-          </li>
-          <li>Let |tasks| be an empty <a>list</a>.
-          </li>
-          <li>For each <a>environment settings object</a> |target| in |targets|:
-            <ol>
-              <li>
-                <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s
-                [=relevant settings object=]'s [=environment settings object/global object=]'s
-                [=Window/browsing context=] to perform the following step:
-                <ol>
-                  <li>Interpret |parameters|.{{PermissionSetParameters/state}} as if it were the
-                  result of an invocation of <a>permission state</a> for |typedDescriptor| with the
-                  argument |target| made at this moment.
-                  </li>
-                </ol>
-              </li>
-              <li>[=list/Append=] |task| to |tasks|.
-              </li>
-            </ol>
-          </li>
-          <li>Wait for all <a>tasks</a> in |tasks| to have executed.
-          </li>
-          <li>Return <a>success</a> with data `null`.
-          </li>
-        </ol>
-        <aside class="example" title="Setting a permission via WebDriver">
+        <section>
+          <h4 id="extension-module-browser">
+            The browser Module
+          </h4>
           <p>
-            To [=extension commands/set permission=] for `{name: "midi", sysex: true}` of the
-            [=current settings object=] of the <a>session</a> with ID 23 to "`granted`", the local
-            end would POST to `/session/23/permissions` with the body:
+            The [=modules/browser=] module contains commands for
+            managing the remote end browser process.
           </p>
-          <pre class="lang-json">
-          {
-            "descriptor": {
-              "name": "midi",
-              "sysex": true
-            },
-            "state": "granted"
-          }
-          </pre>
-        </aside>
+          <section>
+            <h5 id="extension-module-browser-definition">
+              Definition
+            </h5>
+            <p>
+              [=remote end definition=]
+            </p>
+            <pre class="cddl remote-cddl">
+              BrowserCommand = (
+                browser.setPermission
+              )
+            </pre>
+          </section>
+          <section>
+            <h5 id="extension-module-browser-types">
+              Types
+            </h5>
+            <section>
+              <h6 id="extension-module-type-browser-PermissionDescriptor">
+                The browser.PermissionDescriptor Type
+              </h6>
+              <pre class="cddl local-cddl">
+                browser.PermissionDescriptor = {
+                  type: "permissionDescriptor",
+                  name: text,
+                }
+              </pre>
+              <p>
+                The <code>browser.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
+              </p>
+            </section>
+            <section>
+              <h6 id="extension-module-type-browser-PermissionState">
+                The browser.PermissionState Type
+              </h6>
+              <pre class="cddl local-cddl">
+                browser.PermissionState = "granted" / "denied" / "prompt"
+              </pre>
+              <p>
+                The <code>browser.PermissionState</code> type represents a {{PermissionState}}.
+              </p>
+            </section>
+          </section>
+          <section>
+            <h5 id="extension-module-browser-commands">
+              Commands
+            </h5>
+            <section>
+              <h6 id="extension-module-command-browser-setPermission">
+                The browser.setPermission Command
+              </h6>
+              <p>
+                The <dfn class="export" data-dfn-for="extension modules">Set Permission</dfn>
+                [=extension module=] simulates user modification of a {{PermissionDescriptor}}'s
+                [=permission state=].
+              </p>
+              <dl>
+                <dt>Command Type</dt>
+                <dd>
+                  <pre class="cddl remote-cddl">
+                    browser.setPermission = (
+                      method: "browser.setPermission",
+                      params: browser.SetPermissionParameters
+                    )
+
+                    browser.SetPermissionParameters = {
+                      descriptor: browser.PermissionDescriptor,
+                      state: browser.PermissionState,
+                      ? context: browsingContext.BrowsingContext,
+                      ? origin: text,
+                    }
+                  </pre>
+                </dd>
+                <dt>Result Type</dt>
+                <dd>
+                  <pre class="cddl">
+                    EmptyResult
+                  </pre>
+                </dd>
+             </dl>
+             <div algorithm="remote end steps for permissions.setPermission">
+               <p>
+                 The [=remote end steps=] with |session| and |command parameters| are:
+               </p>
+               <ol>
+                <li>
+                  Let |descriptor| be the value of the <code>descriptor</code> field of
+   |command parameters|.
+                </li>
+                <li>
+                  Let |state| be the value of the <code>state</code> field of |command
+   parameters|.
+                </li>
+                <li>
+                  Let |context id| be the value of the <code>context</code> field of
+   |command parameters|.
+                </li>
+                <li>
+                  If |context id| is not present, let |context| be the [=top-level browsing context=]
+   of |session|. Otherwise, let |context| be the result of [=trying=] to
+   [=get a browsing context=] with |context id|.
+                </li>
+                <li>
+                  Let |permission name| be the value of the <code>name</code> field of
+   |descriptor| representing {{PermissionDescriptor/name}}.
+                </li>
+                <li>
+                  [=Convert to an IDL value=] (|descriptor|, |state|) of type {{PermissionSetParameters}}.
+   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
+                </li>
+                <li>
+                  Let |typedDescriptor| be the object |descriptor| refers to, <a>converted to an IDL
+                    value</a> of |permission name|'s [=powerful
+                    feature/permission descriptor type=]. If this throws an exception,
+                    return [=error=] with [=error code=] [=invalid argument=].
+                </li>
+                <li>
+                  If |state| is an inappropriate [=permission state=] for any
+   implementation-defined reason, return [=error=] with [=error code=] [=invalid argument=].
+                </li>
+                <li>
+                  Let |settings| be the [=current settings object=].
+                </li>
+                <li>
+                  Let |targets| be a [=/list=] containing all [=environment settings object=]
+   whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
+   the [=environment settings object/origin=] of |settings|.
+                </li>
+                <li>
+                  Let |tasks| be an empty [=/list=].
+                </li>
+                <li>
+                  For each [=environment settings object=] |target| in |targets|:
+                </li>
+                  <ol>
+                    <li>
+                      [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
+      [=relevant settings object=]'s [=environment settings object/global object=]'s
+      [=Window/browsing context=] to perform the following step:
+                    </li>
+                    <ol>
+                      <li>
+                        Interpret |state| as if it were the result of an invocation of [=permission state=]
+         for |typedDescriptor| with the argument |target| made at this moment.
+                      </li>
+                    </ol>
+                    <li>
+                      [=list/Append=] |task| to |tasks|.
+                    </li>
+                  </ol>
+                <li>
+                  Wait for all <a>tasks</a> in |tasks| to have executed.
+                </li>
+                <li>
+                  Return [=success=] with data null.
+                </li>
+               </ol>
+               <!-- TODO: Use origin. -->
+             </div>
+            </section>
+          </section>
+        </section>
+      </section>
+      <section data-cite="webdriver">
+        <h3 id="automation-webdriver">
+          Automated testing with [[WebDriver]]
+        </h3>
+        <p>
+          This document defines the following <a>extension commands</a> for the [[WebDriver]] specification.
+        </p>
+        <section>
+          <h4 id="set-permission-command">
+            Set Permission
+          </h4>
+          <table>
+            <tbody>
+              <tr>
+                <th>
+                  HTTP Method
+                </th>
+                <th>
+                  <a data-lt="extension command URI template">URI Template</a>
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  POST
+                </td>
+                <td>
+                  /session/{session id}/permissions
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            The <dfn class="export" data-dfn-for="extension commands">Set Permission</dfn>
+            <a>extension command</a> simulates user modification of a {{PermissionDescriptor}}'s
+            <a>permission state</a>.
+          </p>
+          <p>
+            The <a>remote end steps</a> are:
+          </p>
+          <ol>
+            <li>Let |parameters| be the |parameters| argument, <a>converted to an IDL value</a> of
+            type {{PermissionSetParameters}}. If this throws an exception, return an [=invalid
+            argument=] [=error=].
+            </li>
+            <li>Let |rootDesc| be |parameters|.{{PermissionSetParameters/descriptor}}.
+            </li>
+            <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
+            value</a> of <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s [=powerful
+            feature/permission descriptor type=]. If this throws an exception, return a [=invalid
+            argument=] [=error=].
+            </li>
+            <li>If |parameters|.{{PermissionSetParameters/state}} is an inappropriate <a>permission
+            state</a> for any implementation-defined reason, return a [=invalid argument=] [=error=].
+              <p class="note">
+                For example, <a>user agents</a> that define the "midi" <a>powerful feature</a> as
+                "always on" may choose to reject a command to set the <a>permission state</a> to
+                {{PermissionState/"denied"}} at this step.
+              </p>
+            </li>
+            <li>Let |settings| be the [=current settings object=].
+            </li>
+            <li>Let |targets| be a <a>list</a> containing all <a>environment settings objects</a>
+            whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
+            the [=environment settings object/origin=] of |settings|.
+            </li>
+            <li>Let |tasks| be an empty <a>list</a>.
+            </li>
+            <li>For each <a>environment settings object</a> |target| in |targets|:
+              <ol>
+                <li>
+                  <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s
+                  [=relevant settings object=]'s [=environment settings object/global object=]'s
+                  [=Window/browsing context=] to perform the following step:
+                  <ol>
+                    <li>Interpret |parameters|.{{PermissionSetParameters/state}} as if it were the
+                    result of an invocation of <a>permission state</a> for |typedDescriptor| with the
+                    argument |target| made at this moment.
+                    </li>
+                  </ol>
+                </li>
+                <li>[=list/Append=] |task| to |tasks|.
+                </li>
+              </ol>
+            </li>
+            <li>Wait for all <a>tasks</a> in |tasks| to have executed.
+            </li>
+            <li>Return <a>success</a> with data `null`.
+            </li>
+          </ol>
+          <aside class="example" title="Setting a permission via WebDriver">
+            <p>
+              To [=extension commands/set permission=] for `{name: "midi", sysex: true}` of the
+              [=current settings object=] of the <a>session</a> with ID 23 to "`granted`", the local
+              end would POST to `/session/23/permissions` with the body:
+            </p>
+            <pre class="lang-json">
+            {
+              "descriptor": {
+                "name": "midi",
+                "sysex": true
+              },
+              "state": "granted"
+            }
+            </pre>
+          </aside>
+        </section>
       </section>
     </section>
     <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -1194,14 +1194,12 @@
       </pre>
       <p>To <dfn>set a permission</dfn> given <var>descriptor</var>, and <var>state</var>:
       <ol class="algorithm">
-        <li>Let |settings| be the [=current settings object=].
-        </li>
+        <li>Let |settings| be the [=current settings object=].</li>
         <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=]
         whose [=environment settings object/origin=] is [=same origin=] as
         the [=environment settings object/origin=] of |settings|.
         </li>
-        <li>Let |tasks| be an empty <a>list</a>.
-        </li>
+        <li>Let |tasks| be an empty <a>list</a>.</li>
         <li>For each <a>environment settings object</a> |target| in |targets|:
           <ol>
             <li>
@@ -1215,12 +1213,10 @@
                 </li>
               </ol>
             </li>
-            <li>[=list/Append=] |task| to |tasks|.
-            </li>
+            <li>[=list/Append=] |task| to |tasks|.</li>
           </ol>
         </li>
-        <li>Wait for all <a>tasks</a> in |tasks| to have executed.
-        </li>
+        <li>Wait for all <a>tasks</a> in |tasks| to have executed.</li>
       </ol>
       <section data-cite="webdriver">
         <h3 id="automation-webdriver">
@@ -1397,13 +1393,13 @@
                   </pre>
                 </dd>
              </dl>
-             <ol algorithm="remote end steps for permissions.setPermission">
-               <p>
-                TODO: Add user `context` to `SetPermissionParameters`.
-               </p>
-               <p>
-                TODO: Add `origin`.
-               </p>
+             <p>
+              TODO: Add `user context` to `SetPermissionParameters`.
+             </p>
+             <p>
+              TODO: Add `origin` to `SetPermissionParameters`.
+             </p>
+             <div class="algorithm" data-algorithm="remote end steps for permissions.setPermission">
                <p>
                  The [=remote end steps=] with |session| and |command parameters| are:
                </p>
@@ -1429,14 +1425,10 @@
                   {{PermissionSetParameters}} |permission name|'s [=powerful feature/permission descriptor type=].
                   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
                 </li>
-                <li>
-                  [=Set a permission=] with |typedDescriptor| and |state|.
-                </li>
-                <li>
-                  Return [=success=] with data null.
-                </li>
+                <li>[=Set a permission=] with |typedDescriptor| and |state|.</li>
+                <li>Return [=success=] with data null.</li>
                </ol>
-             </ol>
+             </>
             </section>
           </section>
         </section>

--- a/index.html
+++ b/index.html
@@ -1299,182 +1299,182 @@
           </aside>
         </section>
       </section>
-    </section>
-    <section data-cite="webdriver webdriver2 webdriver-bidi">
-      <h3 id="automation-webdriver-bidi">
-        Automated testing with [[WebDriver-BiDi]]
-      </h3>
-      <p>
-        This document defines the following [=extension modules=] for the [[WebDriver-BiDi]] specification.
-      </p>
-      <section>
-        <h4 id="extension-module-permissions">
-          The permissions Module
-        </h4>
+      <section data-cite="webdriver webdriver2 webdriver-bidi">
+        <h3 id="automation-webdriver-bidi">
+          Automated testing with [[WebDriver-BiDi]]
+        </h3>
         <p>
-          The <dfn>permissions</dfn> module contains commands for
-          managing the remote end browser permissions.
+          This document defines the following [=extension modules=] for the [[WebDriver-BiDi]] specification.
         </p>
         <section>
-          <h5 id="extension-module-permissions-definition">
-            Definition
-          </h5>
+          <h4 id="extension-module-permissions">
+            The permissions Module
+          </h4>
           <p>
-            [=remote end definition=]
+            The <dfn>permissions</dfn> module contains commands for
+            managing the remote end browser permissions.
           </p>
-          <pre class="cddl remote-cddl">
-            PermissionsCommand = (
-              permissions.setPermission
-            )
-          </pre>
-        </section>
-        <section>
-          <h5 id="extension-module-permissions-types">
-            Types
-          </h5>
           <section>
-            <h6 id="extension-module-type-permissions-PermissionDescriptor">
-              The permissions.PermissionDescriptor Type
-            </h6>
-            <pre class="cddl local-cddl">
-              permissions.PermissionDescriptor = {
-                type: "permissionDescriptor",
-                name: text,
-              }
-            </pre>
+            <h5 id="extension-module-permissions-definition">
+              Definition
+            </h5>
             <p>
-              The <code>permissions.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
+              [=remote end definition=]
             </p>
+            <pre class="cddl remote-cddl">
+              PermissionsCommand = (
+                permissions.setPermission
+              )
+            </pre>
           </section>
           <section>
-            <h6 id="extension-module-type-permissions-PermissionState">
-              The permissions.PermissionState Type
-            </h6>
-            <pre class="cddl local-cddl">
-              permissions.PermissionState = "granted" / "denied" / "prompt"
-            </pre>
-            <p>
-              The <code>permissions.PermissionState</code> type represents a {{PermissionState}}.
-            </p>
+            <h5 id="extension-module-permissions-types">
+              Types
+            </h5>
+            <section>
+              <h6 id="extension-module-type-permissions-PermissionDescriptor">
+                The permissions.PermissionDescriptor Type
+              </h6>
+              <pre class="cddl local-cddl">
+                permissions.PermissionDescriptor = {
+                  type: "permissionDescriptor",
+                  name: text,
+                }
+              </pre>
+              <p>
+                The <code>permissions.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
+              </p>
+            </section>
+            <section>
+              <h6 id="extension-module-type-permissions-PermissionState">
+                The permissions.PermissionState Type
+              </h6>
+              <pre class="cddl local-cddl">
+                permissions.PermissionState = "granted" / "denied" / "prompt"
+              </pre>
+              <p>
+                The <code>permissions.PermissionState</code> type represents a {{PermissionState}}.
+              </p>
+            </section>
           </section>
-        </section>
-        <section>
-          <h5 id="extension-module-permissions-commands">
-            Commands
-          </h5>
           <section>
-            <h6 id="extension-module-command-permissions-setPermission">
-              The permissions.setPermission Command
-            </h6>
-            <p>
-              The <dfn class="export" data-dfn-for="extension modules">Set Permission</dfn>
-              [=extension module=] simulates user modification of a {{PermissionDescriptor}}'s
-              [=permission state=].
-            </p>
-            <dl>
-              <dt>Command Type</dt>
-              <dd>
-                <pre class="cddl remote-cddl">
-                  permissions.setPermission = (
-                    method: "permissions.setPermission",
-                    params: permissions.SetPermissionParameters
-                  )
+            <h5 id="extension-module-permissions-commands">
+              Commands
+            </h5>
+            <section>
+              <h6 id="extension-module-command-permissions-setPermission">
+                The permissions.setPermission Command
+              </h6>
+              <p>
+                The <dfn class="export" data-dfn-for="extension modules">Set Permission</dfn>
+                [=extension module=] simulates user modification of a {{PermissionDescriptor}}'s
+                [=permission state=].
+              </p>
+              <dl>
+                <dt>Command Type</dt>
+                <dd>
+                  <pre class="cddl remote-cddl">
+                    permissions.setPermission = (
+                      method: "permissions.setPermission",
+                      params: permissions.SetPermissionParameters
+                    )
 
-                  permissions.SetPermissionParameters = {
-                    descriptor: permissions.PermissionDescriptor,
-                    state: permissions.PermissionState,
-                    ? context: browsingContext.BrowsingContext,
-                    ? origin: text,
-                  }
-                </pre>
-              </dd>
-              <dt>Result Type</dt>
-              <dd>
-                <pre class="cddl">
-                  EmptyResult
-                </pre>
-              </dd>
-           </dl>
-           <div algorithm="remote end steps for permissions.setPermission">
-             <p>
-               The [=remote end steps=] with |session| and |command parameters| are:
-             </p>
-             <ol>
-              <li>
-                Let |descriptor| be the value of the <code>descriptor</code> field of
- |command parameters|.
-              </li>
-              <li>
-                Let |state| be the value of the <code>state</code> field of |command
- parameters|.
-              </li>
-              <li>
-                Let |context id| be the value of the <code>context</code> field of
- |command parameters|.
-              </li>
-              <li>
-                If |context id| is not present, let |context| be the [=top-level browsing context=]
- of |session|. Otherwise, let |context| be the result of [=trying=] to
- [=get a browsing context=] with |context id|.
-              </li>
-              <li>
-                Let |permission name| be the value of the <code>name</code> field of
- |descriptor| representing {{PermissionDescriptor/name}}.
-              </li>
-              <li>
-                <!-- TODO: Only convert to an IDL value only once. -->
-                [=Convert to an IDL value=] (|descriptor|, |state|) of type {{PermissionSetParameters}}.
- If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
-              </li>
-              <li>
-                Let |typedDescriptor| be the object |descriptor| refers to, <a>converted to an IDL
-                  value</a> of |permission name|'s [=powerful
-                  feature/permission descriptor type=]. If this throws an exception,
-                  return [=error=] with [=error code=] [=invalid argument=].
-              </li>
-              <li>
-                If |state| is an inappropriate [=permission state=] for any
- implementation-defined reason, return [=error=] with [=error code=] [=invalid argument=].
-              </li>
-              <li>
-                Let |settings| be the [=current settings object=].
-              </li>
-              <li>
-                Let |targets| be a [=/list=] containing all [=environment settings object=]
- whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
- the [=environment settings object/origin=] of |settings|.
-              </li>
-              <li>
-                Let |tasks| be an empty [=/list=].
-              </li>
-              <li>
-                For each [=environment settings object=] |target| in |targets|:
-              </li>
-                <ol>
-                  <li>
-                    [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
-    [=relevant settings object=]'s [=environment settings object/global object=]'s
-    [=Window/browsing context=] to perform the following step:
-                  </li>
+                    permissions.SetPermissionParameters = {
+                      descriptor: permissions.PermissionDescriptor,
+                      state: permissions.PermissionState,
+                      ? context: browsingContext.BrowsingContext,
+                      ? origin: text,
+                    }
+                  </pre>
+                </dd>
+                <dt>Result Type</dt>
+                <dd>
+                  <pre class="cddl">
+                    EmptyResult
+                  </pre>
+                </dd>
+             </dl>
+             <div algorithm="remote end steps for permissions.setPermission">
+               <p>
+                 The [=remote end steps=] with |session| and |command parameters| are:
+               </p>
+               <ol>
+                <li>
+                  Let |descriptor| be the value of the <code>descriptor</code> field of
+   |command parameters|.
+                </li>
+                <li>
+                  Let |state| be the value of the <code>state</code> field of |command
+   parameters|.
+                </li>
+                <li>
+                  Let |context id| be the value of the <code>context</code> field of
+   |command parameters|.
+                </li>
+                <li>
+                  If |context id| is not present, let |context| be the [=top-level browsing context=]
+   of |session|. Otherwise, let |context| be the result of [=trying=] to
+   [=get a browsing context=] with |context id|.
+                </li>
+                <li>
+                  Let |permission name| be the value of the <code>name</code> field of
+   |descriptor| representing {{PermissionDescriptor/name}}.
+                </li>
+                <li>
+                  <!-- TODO: Only convert to an IDL value only once. -->
+                  [=Convert to an IDL value=] (|descriptor|, |state|) of type {{PermissionSetParameters}}.
+   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
+                </li>
+                <li>
+                  Let |typedDescriptor| be the object |descriptor| refers to, <a>converted to an IDL
+                    value</a> of |permission name|'s [=powerful
+                    feature/permission descriptor type=]. If this throws an exception,
+                    return [=error=] with [=error code=] [=invalid argument=].
+                </li>
+                <li>
+                  If |state| is an inappropriate [=permission state=] for any
+   implementation-defined reason, return [=error=] with [=error code=] [=invalid argument=].
+                </li>
+                <li>
+                  Let |settings| be the [=current settings object=].
+                </li>
+                <li>
+                  Let |targets| be a [=/list=] containing all [=environment settings object=]
+   whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
+   the [=environment settings object/origin=] of |settings|.
+                </li>
+                <li>
+                  Let |tasks| be an empty [=/list=].
+                </li>
+                <li>
+                  For each [=environment settings object=] |target| in |targets|:
+                </li>
                   <ol>
                     <li>
-                      Interpret |state| as if it were the result of an invocation of [=permission state=]
-       for |typedDescriptor| with the argument |target| made at this moment.
+                      [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
+      [=relevant settings object=]'s [=environment settings object/global object=]'s
+      [=Window/browsing context=] to perform the following step:
+                    </li>
+                    <ol>
+                      <li>
+                        Interpret |state| as if it were the result of an invocation of [=permission state=]
+         for |typedDescriptor| with the argument |target| made at this moment.
+                      </li>
+                    </ol>
+                    <li>
+                      [=list/Append=] |task| to |tasks|.
                     </li>
                   </ol>
-                  <li>
-                    [=list/Append=] |task| to |tasks|.
-                  </li>
-                </ol>
-              <li>
-                Wait for all <a>tasks</a> in |tasks| to have executed.
-              </li>
-              <li>
-                Return [=success=] with data null.
-              </li>
-             </ol>
-             <!-- TODO: Use origin. -->
-           </div>
+                <li>
+                  Wait for all <a>tasks</a> in |tasks| to have executed.
+                </li>
+                <li>
+                  Return [=success=] with data null.
+                </li>
+               </ol>
+               <!-- TODO: Use origin. -->
+             </div>
+            </section>
           </section>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -1196,7 +1196,7 @@
       <ol class="algorithm">
         <li>Let |settings| be the [=current settings object=].
         </li>
-        <li>Let |targets| be a <a>list</a> containing all <a>environment settings objects</a>
+        <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=]
         whose [=environment settings object/origin=] is [=same origin=] as
         the [=environment settings object/origin=] of |settings|.
         </li>

--- a/index.html
+++ b/index.html
@@ -1282,7 +1282,7 @@
             argument=] [=error=].
             </li>
             <li>
-              Run the [=set a permission=] algorithm, passing |typedDescriptor| and |parameters|.{{PermissionSetParameters/state}}.
+              [=Set a permission=] with |typedDescriptor| and |parameters|.{{PermissionSetParameters/state}}.
             </li>
             <li>Return <a>success</a> with data `null`.
             </li>
@@ -1431,7 +1431,7 @@
                   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
                 </li>
                 <li>
-                  Run the [=set a permission=] algorithm, passing |typedDescriptor| and |state|.
+                  [=Set a permission=] with |typedDescriptor| and |state|.
                 </li>
                 <li>
                   Return [=success=] with data null.

--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@
           <p>
             If a {{DOMString}} |name| names one of these features, then |name|'s <dfn data-dfn-for=
             "powerful feature" class="export">extra permission data</dfn> for an optional
-            <a>environment settings object</a> |settings| is the result of the following algorithm:
+            [=environment settings object=] |settings| is the result of the following algorithm:
           </p>
           <ol class="algorithm">
             <li>If |settings| wasn't passed, set it to the [=current settings object=].
@@ -760,7 +760,7 @@
         </ol>
         <p>
           A |descriptor|'s <dfn class="export">permission state</dfn>, given an optional
-          <a>environment settings object</a> |settings| is the result of the following algorithm.
+          [=environment settings object=] |settings| is the result of the following algorithm.
           It returns a {{PermissionState}} enum value:
         </p>
         <ol class="algorithm">
@@ -1203,7 +1203,7 @@
           the [=environment settings object/origin=] of |settings|.
           </li>
           <li>Let |tasks| be an empty <a>list</a>.</li>
-          <li>For each <a>environment settings object</a> |target| in |targets|:
+          <li>For each [=environment settings object=] |target| in |targets|:
             <ol>
               <li>
                 <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s

--- a/index.html
+++ b/index.html
@@ -1192,33 +1192,36 @@
           required PermissionState state;
         };
       </pre>
-        To <dfn data-for="WebDriver">set a permission</dfn> given a {{PermissionDescriptor}} |descriptor:PermissionDescriptor|, and a {{PermissionState}} |state:PermissionState|:
-      </p>
-      <ol class="algorithm">
-        <li>Let |settings| be the [=current settings object=].</li>
-        <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=]
-        whose [=environment settings object/origin=] is [=same origin=] as
-        the [=environment settings object/origin=] of |settings|.
-        </li>
-        <li>Let |tasks| be an empty <a>list</a>.</li>
-        <li>For each <a>environment settings object</a> |target| in |targets|:
-          <ol>
-            <li>
-              <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s
-              [=relevant settings object=]'s [=environment settings object/global object=]'s
-              [=Window/browsing context=] to perform the following step:
-              <ol>
-                <li>Interpret |state| as if it were the
-                result of an invocation of <a>permission state</a> for |descriptor| with the
-                argument |target| made at this moment.
-                </li>
-              </ol>
-            </li>
-            <li>[=list/Append=] |task| to |tasks|.</li>
-          </ol>
-        </li>
-        <li>Wait for all <a>tasks</a> in |tasks| to have executed and return.</li>
-      </ol>
+      <div class="algorithm">
+        <p>
+          To <dfn data-for="WebDriver">set a permission</dfn> given a {{PermissionDescriptor}} |descriptor:PermissionDescriptor|, and a {{PermissionState}} |state:PermissionState|:
+        </p>
+        <ol>
+          <li>Let |settings| be the [=current settings object=].</li>
+          <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=]
+          whose [=environment settings object/origin=] is [=same origin=] as
+          the [=environment settings object/origin=] of |settings|.
+          </li>
+          <li>Let |tasks| be an empty <a>list</a>.</li>
+          <li>For each <a>environment settings object</a> |target| in |targets|:
+            <ol>
+              <li>
+                <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s
+                [=relevant settings object=]'s [=environment settings object/global object=]'s
+                [=Window/browsing context=] to perform the following step:
+                <ol>
+                  <li>Interpret |state| as if it were the
+                  result of an invocation of <a>permission state</a> for |descriptor| with the
+                  argument |target| made at this moment.
+                  </li>
+                </ol>
+              </li>
+              <li>[=list/Append=] |task| to |tasks|.</li>
+            </ol>
+          </li>
+          <li>Wait for all <a>tasks</a> in |tasks| to have executed and return.</li>
+        </ol>
+      </div>
       <section data-cite="webdriver">
         <h3 id="automation-webdriver">
           Automated testing with [[WebDriver]]
@@ -1423,7 +1426,7 @@
                 <li>[=Set a permission=] with |typedDescriptor| and |state|.</li>
                 <li>Return [=success=] with data `null`.</li>
                </ol>
-             </>
+             </d>
             </section>
           </section>
         </section>

--- a/index.html
+++ b/index.html
@@ -510,8 +510,8 @@
           <aside class="example" id="example-stronger-than" title=
           "A permission descriptor that defines a partial order">
             <p>
-              <code>{name: "midi", sysex: true}</code> ("midi-with-sysex") is
-              [=PermissionDescriptor/stronger than=] <code>{name: "midi", sysex: false}</code>
+              `{name: "midi", sysex: true}` ("midi-with-sysex") is
+              [=PermissionDescriptor/stronger than=] `{name: "midi", sysex: false}`
               ("midi-without-sysex"), so if the user denies access to midi-without-sysex, the UA
               must also deny access to midi-with-sysex, and similarly if the user grants access to
               midi-with-sysex, the user agent must also grant access to midi-without-sysex.
@@ -594,7 +594,7 @@
             runs the following steps:
           </p>
           <ol class="algorithm">
-            <li>Set <code>|status|</code>'s {{PermissionStatus/state}} to |permissionDesc|'s
+            <li>Set `|status|`'s {{PermissionStatus/state}} to |permissionDesc|'s
             <a>permission state</a>.
             </li>
           </ol>
@@ -1088,7 +1088,7 @@
           </h4>
           <p>
             The <dfn>onchange</dfn> attribute is an <a>event handler</a> whose corresponding
-            <a>event handler event type</a> is <code>change</code>.
+            <a>event handler event type</a> is `change`.
           </p>
           <p id="PermissionStatus-update">
             Whenever the [=user agent=] is aware that the state of a {{PermissionStatus}} instance
@@ -1113,7 +1113,7 @@
             </li>
             <li>
               <a>Queue a task</a> on the [=permissions task source=] to <a>fire an event</a> named
-              <code>change</code> at |status|.
+              `change` at |status|.
             </li>
           </ol>
         </section>
@@ -1277,7 +1277,7 @@
               </p>
             </li>
             <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
-            value</a> of <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s [=powerful
+            value</a> of `|rootDesc|.{{PermissionDescriptor/name}}`'s [=powerful
             feature/permission descriptor type=]. If this throws an exception, return a [=invalid
             argument=] [=error=].
             </li>
@@ -1347,7 +1347,7 @@
                 }
               </pre>
               <p>
-                The <code>permissions.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
+                The `permissions.PermissionDescriptor` type represents a {{PermissionDescriptor}}.
               </p>
             </section>
             <section>
@@ -1358,7 +1358,7 @@
                 permissions.PermissionState = "granted" / "denied" / "prompt"
               </pre>
               <p>
-                The <code>permissions.PermissionState</code> type represents a {{PermissionState}}.
+                The `permissions.PermissionState` type represents a {{PermissionState}}.
               </p>
             </section>
           </section>
@@ -1399,25 +1399,25 @@
              </dl>
              <ol algorithm="remote end steps for permissions.setPermission">
                <p>
-                TODO: Add user <code>context</code> to <code>SetPermissionParameters</code>.
+                TODO: Add user `context` to `SetPermissionParameters`.
                </p>
                <p>
-                TODO: Add <code>origin</code>.
+                TODO: Add `origin`.
                </p>
                <p>
                  The [=remote end steps=] with |session| and |command parameters| are:
                </p>
                <ol>
                 <li>
-                  Let |descriptor| be the value of the <code>descriptor</code> field of
+                  Let |descriptor| be the value of the `descriptor` field of
    |command parameters|.
                 </li>
                 <li>
-                  Let |permission name| be the value of the <code>name</code> field of
+                  Let |permission name| be the value of the `name` field of
              |descriptor| representing {{PermissionDescriptor/name}}.
                 </li>
                 <li>
-                  Let |state| be the value of the <code>state</code> field of |command
+                  Let |state| be the value of the `state` field of |command
    parameters|.
                 </li>
                 <li>

--- a/index.html
+++ b/index.html
@@ -1240,7 +1240,7 @@
                   HTTP Method
                 </th>
                 <th>
-                  <a data-lt="extension command URI template">URI Template</a>
+                  [=extension command URI template|URI Template=]
                 </th>
               </tr>
               <tr>

--- a/index.html
+++ b/index.html
@@ -1293,7 +1293,7 @@
               [=current settings object=] of the <a>session</a> with ID 23 to "`granted`", the local
               end would POST to `/session/23/permissions` with the body:
             </p>
-            <pre class="lang-json">
+            <pre class="json">
             {
               "descriptor": {
                 "name": "midi",

--- a/index.html
+++ b/index.html
@@ -1393,12 +1393,6 @@
                   </pre>
                 </dd>
              </dl>
-             <p>
-              TODO: Add `user context` to `SetPermissionParameters`.
-             </p>
-             <p>
-              TODO: Add `origin` to `SetPermissionParameters`.
-             </p>
              <div class="algorithm" data-algorithm="remote end steps for permissions.setPermission">
                <p>
                  The [=remote end steps=] with |session| and |command parameters| are:

--- a/index.html
+++ b/index.html
@@ -1197,7 +1197,7 @@
         <li>Let |settings| be the [=current settings object=].
         </li>
         <li>Let |targets| be a <a>list</a> containing all <a>environment settings objects</a>
-        whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
+        whose [=environment settings object/origin=] is [=same origin=] as
         the [=environment settings object/origin=] of |settings|.
         </li>
         <li>Let |tasks| be an empty <a>list</a>.

--- a/index.html
+++ b/index.html
@@ -1216,7 +1216,7 @@
             <li>[=list/Append=] |task| to |tasks|.</li>
           </ol>
         </li>
-        <li>Wait for all <a>tasks</a> in |tasks| to have executed.</li>
+        <li>Wait for all <a>tasks</a> in |tasks| to have executed and return.</li>
       </ol>
       <section data-cite="webdriver">
         <h3 id="automation-webdriver">

--- a/index.html
+++ b/index.html
@@ -1192,7 +1192,8 @@
           required PermissionState state;
         };
       </pre>
-      <p>To <dfn>set a permission</dfn> given <var>descriptor</var>, and <var>state</var>:
+        To <dfn data-for="WebDriver">set a permission</dfn> given a {{PermissionDescriptor}} |descriptor:PermissionDescriptor|, and a {{PermissionState}} |state:PermissionState|:
+      </p>
       <ol class="algorithm">
         <li>Let |settings| be the [=current settings object=].</li>
         <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=]

--- a/index.html
+++ b/index.html
@@ -310,7 +310,7 @@
             [=permission store entry/descriptor=] is |descriptor|, and whose [=permission store
             entry/key=] [=permission key/is equal to=] |key| given |descriptor|, return that entry.
           </li>
-          <li>Return null.
+          <li>Return `null`.
           </li>
         </ol>
         <p>
@@ -787,7 +787,7 @@
           <li>Let |entry| be the result of [=get a permission store entry|getting a permission
           store entry=] with |descriptor| and |key|.
           </li>
-          <li>If |entry| is not null, return a {{PermissionState}} enum value from |entry|'s
+          <li>If |entry| is not `null`, return a {{PermissionState}} enum value from |entry|'s
           [=permission store entry/state=].
           </li>
           <li>Return the {{PermissionState}} enum value that represents the permission state of
@@ -1101,7 +1101,7 @@
                 <li>Let |document| be |status|'s [=relevant global object=]'s [=associated
                 Document=].
                 </li>
-                <li>If |document| is null or |document| is not [=Document/fully active=], terminate
+                <li>If |document| is `null` or |document| is not [=Document/fully active=], terminate
                 this algorithm.
                 </li>
               </ol>
@@ -1420,7 +1420,7 @@
                   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
                 </li>
                 <li>[=Set a permission=] with |typedDescriptor| and |state|.</li>
-                <li>Return [=success=] with data null.</li>
+                <li>Return [=success=] with data `null`.</li>
                </ol>
              </>
             </section>

--- a/index.html
+++ b/index.html
@@ -1192,184 +1192,6 @@
           required PermissionState state;
         };
       </pre>
-      <section data-cite="webdriver-bidi webdriver">
-        <h3 id="automation-webdriver-bidi">
-          Automated testing with [[WebDriver-BiDi]]
-        </h3>
-        <p>
-          This document defines the following [=extension modules=] for the [[WebDriver-BiDi]] specification.
-        </p>
-        <section>
-          <h4 id="extension-module-browser">
-            The browser Module
-          </h4>
-          <p>
-            The [=modules/browser=] module contains commands for
-            managing the remote end browser process.
-          </p>
-          <section>
-            <h5 id="extension-module-browser-definition">
-              Definition
-            </h5>
-            <p>
-              [=remote end definition=]
-            </p>
-            <pre class="cddl remote-cddl">
-              BrowserCommand = (
-                browser.setPermission
-              )
-            </pre>
-          </section>
-          <section>
-            <h5 id="extension-module-browser-types">
-              Types
-            </h5>
-            <section>
-              <h6 id="extension-module-type-browser-PermissionDescriptor">
-                The browser.PermissionDescriptor Type
-              </h6>
-              <pre class="cddl local-cddl">
-                browser.PermissionDescriptor = {
-                  type: "permissionDescriptor",
-                  name: text,
-                }
-              </pre>
-              <p>
-                The <code>browser.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
-              </p>
-            </section>
-            <section>
-              <h6 id="extension-module-type-browser-PermissionState">
-                The browser.PermissionState Type
-              </h6>
-              <pre class="cddl local-cddl">
-                browser.PermissionState = "granted" / "denied" / "prompt"
-              </pre>
-              <p>
-                The <code>browser.PermissionState</code> type represents a {{PermissionState}}.
-              </p>
-            </section>
-          </section>
-          <section>
-            <h5 id="extension-module-browser-commands">
-              Commands
-            </h5>
-            <section>
-              <h6 id="extension-module-command-browser-setPermission">
-                The browser.setPermission Command
-              </h6>
-              <p>
-                The <dfn class="export" data-dfn-for="extension modules">Set Permission</dfn>
-                [=extension module=] simulates user modification of a {{PermissionDescriptor}}'s
-                [=permission state=].
-              </p>
-              <dl>
-                <dt>Command Type</dt>
-                <dd>
-                  <pre class="cddl remote-cddl">
-                    browser.setPermission = (
-                      method: "browser.setPermission",
-                      params: browser.SetPermissionParameters
-                    )
-
-                    browser.SetPermissionParameters = {
-                      descriptor: browser.PermissionDescriptor,
-                      state: browser.PermissionState,
-                      ? context: browsingContext.BrowsingContext,
-                      ? origin: text,
-                    }
-                  </pre>
-                </dd>
-                <dt>Result Type</dt>
-                <dd>
-                  <pre class="cddl">
-                    EmptyResult
-                  </pre>
-                </dd>
-             </dl>
-             <div algorithm="remote end steps for permissions.setPermission">
-               <p>
-                 The [=remote end steps=] with |session| and |command parameters| are:
-               </p>
-               <ol>
-                <li>
-                  Let |descriptor| be the value of the <code>descriptor</code> field of
-   |command parameters|.
-                </li>
-                <li>
-                  Let |state| be the value of the <code>state</code> field of |command
-   parameters|.
-                </li>
-                <li>
-                  Let |context id| be the value of the <code>context</code> field of
-   |command parameters|.
-                </li>
-                <li>
-                  If |context id| is not present, let |context| be the [=top-level browsing context=]
-   of |session|. Otherwise, let |context| be the result of [=trying=] to
-   [=get a browsing context=] with |context id|.
-                </li>
-                <li>
-                  Let |permission name| be the value of the <code>name</code> field of
-   |descriptor| representing {{PermissionDescriptor/name}}.
-                </li>
-                <li>
-                  [=Convert to an IDL value=] (|descriptor|, |state|) of type {{PermissionSetParameters}}.
-   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
-                </li>
-                <li>
-                  Let |typedDescriptor| be the object |descriptor| refers to, <a>converted to an IDL
-                    value</a> of |permission name|'s [=powerful
-                    feature/permission descriptor type=]. If this throws an exception,
-                    return [=error=] with [=error code=] [=invalid argument=].
-                </li>
-                <li>
-                  If |state| is an inappropriate [=permission state=] for any
-   implementation-defined reason, return [=error=] with [=error code=] [=invalid argument=].
-                </li>
-                <li>
-                  Let |settings| be the [=current settings object=].
-                </li>
-                <li>
-                  Let |targets| be a [=/list=] containing all [=environment settings object=]
-   whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
-   the [=environment settings object/origin=] of |settings|.
-                </li>
-                <li>
-                  Let |tasks| be an empty [=/list=].
-                </li>
-                <li>
-                  For each [=environment settings object=] |target| in |targets|:
-                </li>
-                  <ol>
-                    <li>
-                      [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
-      [=relevant settings object=]'s [=environment settings object/global object=]'s
-      [=Window/browsing context=] to perform the following step:
-                    </li>
-                    <ol>
-                      <li>
-                        Interpret |state| as if it were the result of an invocation of [=permission state=]
-         for |typedDescriptor| with the argument |target| made at this moment.
-                      </li>
-                    </ol>
-                    <li>
-                      [=list/Append=] |task| to |tasks|.
-                    </li>
-                  </ol>
-                <li>
-                  Wait for all <a>tasks</a> in |tasks| to have executed.
-                </li>
-                <li>
-                  Return [=success=] with data null.
-                </li>
-               </ol>
-               <!-- TODO: Use origin. -->
-             </div>
-            </section>
-          </section>
-        </section>
-      </section>
       <section data-cite="webdriver">
         <h3 id="automation-webdriver">
           Automated testing with [[WebDriver]]
@@ -1475,6 +1297,185 @@
             }
             </pre>
           </aside>
+        </section>
+      </section>
+    </section>
+    <section data-cite="webdriver webdriver2 webdriver-bidi">
+      <h3 id="automation-webdriver-bidi">
+        Automated testing with [[WebDriver-BiDi]]
+      </h3>
+      <p>
+        This document defines the following [=extension modules=] for the [[WebDriver-BiDi]] specification.
+      </p>
+      <section>
+        <h4 id="extension-module-browser">
+          The browser Module
+        </h4>
+        <p>
+          The [=modules/browser=] module contains commands for
+          managing the remote end browser process.
+        </p>
+        <section>
+          <h5 id="extension-module-browser-definition">
+            Definition
+          </h5>
+          <p>
+            [=remote end definition=]
+          </p>
+          <pre class="cddl remote-cddl">
+            BrowserCommand = (
+              browser.setPermission
+            )
+          </pre>
+        </section>
+        <section>
+          <h5 id="extension-module-browser-types">
+            Types
+          </h5>
+          <section>
+            <h6 id="extension-module-type-browser-PermissionDescriptor">
+              The browser.PermissionDescriptor Type
+            </h6>
+            <pre class="cddl local-cddl">
+              browser.PermissionDescriptor = {
+                type: "permissionDescriptor",
+                name: text,
+              }
+            </pre>
+            <p>
+              The <code>browser.PermissionDescriptor</code> type represents a {{PermissionDescriptor}}.
+            </p>
+          </section>
+          <section>
+            <h6 id="extension-module-type-browser-PermissionState">
+              The browser.PermissionState Type
+            </h6>
+            <pre class="cddl local-cddl">
+              browser.PermissionState = "granted" / "denied" / "prompt"
+            </pre>
+            <p>
+              The <code>browser.PermissionState</code> type represents a {{PermissionState}}.
+            </p>
+          </section>
+        </section>
+        <section>
+          <h5 id="extension-module-browser-commands">
+            Commands
+          </h5>
+          <section>
+            <h6 id="extension-module-command-browser-setPermission">
+              The browser.setPermission Command
+            </h6>
+            <p>
+              The <dfn class="export" data-dfn-for="extension modules">Set Permission</dfn>
+              [=extension module=] simulates user modification of a {{PermissionDescriptor}}'s
+              [=permission state=].
+            </p>
+            <dl>
+              <dt>Command Type</dt>
+              <dd>
+                <pre class="cddl remote-cddl">
+                  browser.setPermission = (
+                    method: "browser.setPermission",
+                    params: browser.SetPermissionParameters
+                  )
+
+                  browser.SetPermissionParameters = {
+                    descriptor: browser.PermissionDescriptor,
+                    state: browser.PermissionState,
+                    ? context: browsingContext.BrowsingContext,
+                    ? origin: text,
+                  }
+                </pre>
+              </dd>
+              <dt>Result Type</dt>
+              <dd>
+                <pre class="cddl">
+                  EmptyResult
+                </pre>
+              </dd>
+           </dl>
+           <div algorithm="remote end steps for permissions.setPermission">
+             <p>
+               The [=remote end steps=] with |session| and |command parameters| are:
+             </p>
+             <ol>
+              <li>
+                Let |descriptor| be the value of the <code>descriptor</code> field of
+ |command parameters|.
+              </li>
+              <li>
+                Let |state| be the value of the <code>state</code> field of |command
+ parameters|.
+              </li>
+              <li>
+                Let |context id| be the value of the <code>context</code> field of
+ |command parameters|.
+              </li>
+              <li>
+                If |context id| is not present, let |context| be the [=top-level browsing context=]
+ of |session|. Otherwise, let |context| be the result of [=trying=] to
+ [=get a browsing context=] with |context id|.
+              </li>
+              <li>
+                Let |permission name| be the value of the <code>name</code> field of
+ |descriptor| representing {{PermissionDescriptor/name}}.
+              </li>
+              <li>
+                <!-- TODO: Only convert to an IDL value only once. -->
+                [=Convert to an IDL value=] (|descriptor|, |state|) of type {{PermissionSetParameters}}.
+ If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
+              </li>
+              <li>
+                Let |typedDescriptor| be the object |descriptor| refers to, <a>converted to an IDL
+                  value</a> of |permission name|'s [=powerful
+                  feature/permission descriptor type=]. If this throws an exception,
+                  return [=error=] with [=error code=] [=invalid argument=].
+              </li>
+              <li>
+                If |state| is an inappropriate [=permission state=] for any
+ implementation-defined reason, return [=error=] with [=error code=] [=invalid argument=].
+              </li>
+              <li>
+                Let |settings| be the [=current settings object=].
+              </li>
+              <li>
+                Let |targets| be a [=/list=] containing all [=environment settings object=]
+ whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
+ the [=environment settings object/origin=] of |settings|.
+              </li>
+              <li>
+                Let |tasks| be an empty [=/list=].
+              </li>
+              <li>
+                For each [=environment settings object=] |target| in |targets|:
+              </li>
+                <ol>
+                  <li>
+                    [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
+    [=relevant settings object=]'s [=environment settings object/global object=]'s
+    [=Window/browsing context=] to perform the following step:
+                  </li>
+                  <ol>
+                    <li>
+                      Interpret |state| as if it were the result of an invocation of [=permission state=]
+       for |typedDescriptor| with the argument |target| made at this moment.
+                    </li>
+                  </ol>
+                  <li>
+                    [=list/Append=] |task| to |tasks|.
+                  </li>
+                </ol>
+              <li>
+                Wait for all <a>tasks</a> in |tasks| to have executed.
+              </li>
+              <li>
+                Return [=success=] with data null.
+              </li>
+             </ol>
+             <!-- TODO: Use origin. -->
+           </div>
+          </section>
         </section>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1238,11 +1238,6 @@
             </li>
             <li>Let |rootDesc| be |parameters|.{{PermissionSetParameters/descriptor}}.
             </li>
-            <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
-            value</a> of <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s [=powerful
-            feature/permission descriptor type=]. If this throws an exception, return a [=invalid
-            argument=] [=error=].
-            </li>
             <li>If |parameters|.{{PermissionSetParameters/state}} is an inappropriate <a>permission
             state</a> for any implementation-defined reason, return a [=invalid argument=] [=error=].
               <p class="note">
@@ -1250,6 +1245,11 @@
                 "always on" may choose to reject a command to set the <a>permission state</a> to
                 {{PermissionState/"denied"}} at this step.
               </p>
+            </li>
+            <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
+            value</a> of <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s [=powerful
+            feature/permission descriptor type=]. If this throws an exception, return a [=invalid
+            argument=] [=error=].
             </li>
             <li>Let |settings| be the [=current settings object=].
             </li>
@@ -1408,21 +1408,21 @@
    |command parameters|.
                 </li>
                 <li>
+                  Let |permission name| be the value of the <code>name</code> field of
+             |descriptor| representing {{PermissionDescriptor/name}}.
+                </li>
+                <li>
                   Let |state| be the value of the <code>state</code> field of |command
    parameters|.
                 </li>
                 <li>
-                  Let |permission name| be the value of the <code>name</code> field of
-   |descriptor| representing {{PermissionDescriptor/name}}.
+                  If |state| is an inappropriate [=permission state=] for any
+   implementation-defined reason, return [=error=] with [=error code=] [=invalid argument=].
                 </li>
                 <li>
                   Let |typedDescriptor| be the object |descriptor| refers to, [=converted to an IDL value=] (|descriptor|, |state|) of
                   {{PermissionSetParameters}} |permission name|'s [=powerful feature/permission descriptor type=].
                   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
-                </li>
-                <li>
-                  If |state| is an inappropriate [=permission state=] for any
-   implementation-defined reason, return [=error=] with [=error code=] [=invalid argument=].
                 </li>
                 <li>
                   Let |settings| be the [=current settings object=].

--- a/index.html
+++ b/index.html
@@ -1272,7 +1272,7 @@
             state</a> for any implementation-defined reason, return a [=invalid argument=] [=error=].
               <p class="note">
                 For example, <a>user agents</a> that define the "midi" <a>powerful feature</a> as
-                "always on" may choose to reject a command to set the <a>permission state</a> to
+                "always on" can choose to reject a command to set the <a>permission state</a> to
                 {{PermissionState/"denied"}} at this step.
               </p>
             </li>

--- a/index.html
+++ b/index.html
@@ -1226,7 +1226,7 @@
           This document defines the following <a>extension commands</a> for the [[WebDriver]] specification.
         </p>
         <section>
-          <h4 id="set-permission-command">
+          <h4 id="webdriver-command-set-permission">
             Set Permission
           </h4>
           <table>
@@ -1309,7 +1309,7 @@
           This document defines the following [=extension modules=] for the [[WebDriver-BiDi]] specification.
         </p>
         <section>
-          <h4 id="extension-module-permissions">
+          <h4 id="webdriver-bidi-module-permissions">
             The permissions Module
           </h4>
           <p>
@@ -1317,7 +1317,7 @@
             managing the remote end browser permissions.
           </p>
           <section>
-            <h5 id="extension-module-permissions-definition">
+            <h5 id="webdriver-bidi-module-permissions-definition">
               Definition
             </h5>
             <p>
@@ -1330,11 +1330,11 @@
             </pre>
           </section>
           <section>
-            <h5 id="extension-module-permissions-types">
+            <h5 id="webdriver-bidi-module-permissions-types">
               Types
             </h5>
             <section>
-              <h6 id="extension-module-type-permissions-PermissionDescriptor">
+              <h6 id="webdriver-bidi-type-permissions-PermissionDescriptor">
                 The permissions.PermissionDescriptor Type
               </h6>
               <pre class="cddl local-cddl">
@@ -1347,7 +1347,7 @@
               </p>
             </section>
             <section>
-              <h6 id="extension-module-type-permissions-PermissionState">
+              <h6 id="webdriver-bidi-type-permissions-PermissionState">
                 The permissions.PermissionState Type
               </h6>
               <pre class="cddl local-cddl">
@@ -1359,11 +1359,11 @@
             </section>
           </section>
           <section>
-            <h5 id="extension-module-permissions-commands">
+            <h5 id="webdriver-bidi-module-permissions-commands">
               Commands
             </h5>
             <section>
-              <h6 id="extension-module-command-permissions-setPermission">
+              <h6 id="webdriver-bidi-command-permissions-setPermission">
                 The permissions.setPermission Command
               </h6>
               <p>

--- a/index.html
+++ b/index.html
@@ -1382,7 +1382,6 @@
                     permissions.SetPermissionParameters = {
                       descriptor: permissions.PermissionDescriptor,
                       state: permissions.PermissionState,
-                      ? origin: text,
                     }
                   </pre>
                 </dd>
@@ -1394,6 +1393,12 @@
                 </dd>
              </dl>
              <div algorithm="remote end steps for permissions.setPermission">
+               <p>
+                TODO: Add user context to SetPermissionParameters.
+               </p>
+               <p>
+                TODO: Add origin.
+               </p>
                <p>
                  The [=remote end steps=] with |session| and |command parameters| are:
                </p>
@@ -1456,7 +1461,6 @@
                   Return [=success=] with data null.
                 </li>
                </ol>
-               <!-- TODO: Use origin. -->
              </div>
             </section>
           </section>

--- a/index.html
+++ b/index.html
@@ -1192,6 +1192,36 @@
           required PermissionState state;
         };
       </pre>
+      <p>To <dfn>set a permission</dfn> given <var>descriptor</var>, and <var>state</var>:
+      <ol class="algorithm">
+        <li>Let |settings| be the [=current settings object=].
+        </li>
+        <li>Let |targets| be a <a>list</a> containing all <a>environment settings objects</a>
+        whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
+        the [=environment settings object/origin=] of |settings|.
+        </li>
+        <li>Let |tasks| be an empty <a>list</a>.
+        </li>
+        <li>For each <a>environment settings object</a> |target| in |targets|:
+          <ol>
+            <li>
+              <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s
+              [=relevant settings object=]'s [=environment settings object/global object=]'s
+              [=Window/browsing context=] to perform the following step:
+              <ol>
+                <li>Interpret |state| as if it were the
+                result of an invocation of <a>permission state</a> for |descriptor| with the
+                argument |target| made at this moment.
+                </li>
+              </ol>
+            </li>
+            <li>[=list/Append=] |task| to |tasks|.
+            </li>
+          </ol>
+        </li>
+        <li>Wait for all <a>tasks</a> in |tasks| to have executed.
+        </li>
+      </ol>
       <section data-cite="webdriver">
         <h3 id="automation-webdriver">
           Automated testing with [[WebDriver]]
@@ -1251,32 +1281,8 @@
             feature/permission descriptor type=]. If this throws an exception, return a [=invalid
             argument=] [=error=].
             </li>
-            <li>Let |settings| be the [=current settings object=].
-            </li>
-            <li>Let |targets| be a <a>list</a> containing all <a>environment settings objects</a>
-            whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
-            the [=environment settings object/origin=] of |settings|.
-            </li>
-            <li>Let |tasks| be an empty <a>list</a>.
-            </li>
-            <li>For each <a>environment settings object</a> |target| in |targets|:
-              <ol>
-                <li>
-                  <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s
-                  [=relevant settings object=]'s [=environment settings object/global object=]'s
-                  [=Window/browsing context=] to perform the following step:
-                  <ol>
-                    <li>Interpret |parameters|.{{PermissionSetParameters/state}} as if it were the
-                    result of an invocation of <a>permission state</a> for |typedDescriptor| with the
-                    argument |target| made at this moment.
-                    </li>
-                  </ol>
-                </li>
-                <li>[=list/Append=] |task| to |tasks|.
-                </li>
-              </ol>
-            </li>
-            <li>Wait for all <a>tasks</a> in |tasks| to have executed.
+            <li>
+              Run the [=set a permission=] algorithm, passing |typedDescriptor| and |parameters|.{{PermissionSetParameters/state}}.
             </li>
             <li>Return <a>success</a> with data `null`.
             </li>
@@ -1425,37 +1431,7 @@
                   If this conversion throws an exception, return [=error=] with [=error code=] [=invalid argument=].
                 </li>
                 <li>
-                  Let |settings| be the [=current settings object=].
-                </li>
-                <li>
-                  Let |targets| be a [=/list=] containing all [=environment settings object=]
-   whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
-   the [=environment settings object/origin=] of |settings|.
-                </li>
-                <li>
-                  Let |tasks| be an empty [=/list=].
-                </li>
-                <li>
-                  For each [=environment settings object=] |target| in |targets|:
-                </li>
-                <ol>
-                  <li>
-                    [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
-    [=relevant settings object=]'s [=environment settings object/global object=]'s
-    [=Window/browsing context=] to perform the following step:
-                  </li>
-                  <ol>
-                    <li>
-                      Interpret |state| as if it were the result of an invocation of [=permission state=]
-        for |typedDescriptor| with the argument |target| made at this moment.
-                    </li>
-                  </ol>
-                  <li>
-                    [=list/Append=] |task| to |tasks|.
-                  </li>
-                </ol>
-                <li>
-                  Wait for all <a>tasks</a> in |tasks| to have executed.
+                  Run the [=set a permission=] algorithm, passing |typedDescriptor| and |state|.
                 </li>
                 <li>
                   Return [=success=] with data null.

--- a/index.html
+++ b/index.html
@@ -1343,7 +1343,6 @@
               </h6>
               <pre class="cddl local-cddl">
                 permissions.PermissionDescriptor = {
-                  type: "permissionDescriptor",
                   name: text,
                 }
               </pre>

--- a/index.html
+++ b/index.html
@@ -1398,7 +1398,7 @@
                   </pre>
                 </dd>
              </dl>
-             <div algorithm="remote end steps for permissions.setPermission">
+             <ol algorithm="remote end steps for permissions.setPermission">
                <p>
                 TODO: Add user context to SetPermissionParameters.
                </p>
@@ -1437,7 +1437,7 @@
                   Return [=success=] with data null.
                 </li>
                </ol>
-             </div>
+             </ol>
             </section>
           </section>
         </section>

--- a/index.html
+++ b/index.html
@@ -1438,22 +1438,22 @@
                 <li>
                   For each [=environment settings object=] |target| in |targets|:
                 </li>
+                <ol>
+                  <li>
+                    [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
+    [=relevant settings object=]'s [=environment settings object/global object=]'s
+    [=Window/browsing context=] to perform the following step:
+                  </li>
                   <ol>
                     <li>
-                      [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
-      [=relevant settings object=]'s [=environment settings object/global object=]'s
-      [=Window/browsing context=] to perform the following step:
-                    </li>
-                    <ol>
-                      <li>
-                        Interpret |state| as if it were the result of an invocation of [=permission state=]
-         for |typedDescriptor| with the argument |target| made at this moment.
-                      </li>
-                    </ol>
-                    <li>
-                      [=list/Append=] |task| to |tasks|.
+                      Interpret |state| as if it were the result of an invocation of [=permission state=]
+        for |typedDescriptor| with the argument |target| made at this moment.
                     </li>
                   </ol>
+                  <li>
+                    [=list/Append=] |task| to |tasks|.
+                  </li>
+                </ol>
                 <li>
                   Wait for all <a>tasks</a> in |tasks| to have executed.
                 </li>


### PR DESCRIPTION
Based-on: https://github.com/w3c/webdriver-bidi/pull/590
Bug: #424
Bug: https://github.com/w3c/webdriver-bidi/issues/587

Upstream auto-linking blockers:

- [x] https://github.com/w3c/webdriver-bidi/pull/593
- [x] https://github.com/w3c/webdriver-bidi/pull/591
- [x] https://github.com/w3c/webdriver/pull/1766
- [x] https://github.com/w3c/webdriver/pull/1767

Other considerations:

- [x] https://www.w3.org/2023/11/08-webdriver-minutes.html#t04
- ~~<jgraham_> (don't want to extend this topic further, but I always assumed BiDi would move to an event-based model for permissions i.e. you'd get a permissions.Request event with some information)~~:
 
This is out of scope of this initial PR. We intend to only achieve feature parity with WebDriver classic.

- - -

The following tasks have been completed:

 * [x] ~~Modified~~ Web platform tests _commitment_ (link): https://github.com/web-platform-tests/wpt/issues/43305

Implementation commitment:

 * [ ] WebKit (link to issue)
 * [x] Blink (actually, Chromium BiDi mapper): https://github.com/GoogleChromeLabs/chromium-bidi/issues/1585
 * [x] Gecko (link to issue): https://github.com/mozilla/standards-positions/issues/930


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/thiagowfx/permissions/pull/425.html" title="Last updated on Nov 22, 2023, 1:24 PM UTC (0183692)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/425/f647e6d...thiagowfx:0183692.html" title="Last updated on Nov 22, 2023, 1:24 PM UTC (0183692)">Diff</a>