### PR TITLE
Editorial: Replace all <a>foo</a> with [=foo=]

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
         </p>
         <aside class="note" data-cite="appmanifest" title="What constitutes an implicit signal?">
           <p>
-            The <a>implicit signals</a> could be, for example, the [=installed web
+            The [=implicit signals=] could be, for example, the [=installed web
             application|installation=] status of a web application or frequency and recency of
             visits. A user that has installed a web application and used it frequently and recently
             is more likely to trust it. Implementations are advised to exercise caution when
@@ -406,7 +406,7 @@
           "powerful feature">name</dfn>, which is a string literal (e.g., "geolocation").
         </p>
         <p>
-          The user agent tracks which <a>powerful features</a> the user has [=permission=] to use
+          The user agent tracks which [=powerful features=] the user has [=permission=] to use
           via the [=environment settings object=].
         </p>
         <section>
@@ -414,7 +414,7 @@
             Aspects
           </h3>
           <p>
-            Each <a>powerful feature</a> can define zero or more additional <dfn data-dfn-for=
+            Each [=powerful feature=] can define zero or more additional <dfn data-dfn-for=
             "powerful feature">aspects</dfn>. An aspect is defined as WebIDL [=dictionary=] that
             [=dictionary/inherits=] from {{PermissionDescriptor}} and serves as a WebIDL
             interface's [=powerful feature/permission descriptor type=].
@@ -502,10 +502,10 @@
             "https://en.wikipedia.org/wiki/Partially_ordered_set">partial order</a> on descriptor
             instances. If |descriptorA| is <dfn class="export" data-dfn-for=
             "PermissionDescriptor">stronger than</dfn> |descriptorB|, then if |descriptorA|'s
-            <a>permission state</a> is {{PermissionState/"granted"}}, |descriptorB|'s <a>permission
-            state</a> must also be {{PermissionState/"granted"}}, and if |descriptorB|'s
-            <a>permission state</a> is {{PermissionState/"denied"}}, |descriptorA|'s <a>permission
-            state</a> must also be {{PermissionState/"denied"}}.
+            [=permission state=] is {{PermissionState/"granted"}}, |descriptorB|'s [=permission
+            state=] must also be {{PermissionState/"granted"}}, and if |descriptorB|'s
+            [=permission state=] is {{PermissionState/"denied"}}, |descriptorA|'s [=permission
+            state=] must also be {{PermissionState/"denied"}}.
           </p>
           <aside class="example" id="example-stronger-than" title=
           "A permission descriptor that defines a partial order">
@@ -522,15 +522,15 @@
           <dfn data-dfn-for="powerful feature" class="export">permission state constraints</dfn>:
         </dt>
         <dd>
-          Constraints on the values that the user agent can return as a descriptor's <a>permission
-          state</a>. Defaults to no constraints beyond the user's intent.
+          Constraints on the values that the user agent can return as a descriptor's [=permission
+          state=]. Defaults to no constraints beyond the user's intent.
         </dd>
         <dt>
           <dfn data-dfn-for="powerful feature" class="export">extra permission data type</dfn>:
         </dt>
         <dd>
           <p>
-            Some <a>powerful features</a> have more information associated with them than just a
+            Some [=powerful features=] have more information associated with them than just a
             {{PermissionState}}. Each of these features defines an [=powerful feature/extra
             permission data type=].
           </p>
@@ -541,14 +541,14 @@
           <p>
             If a {{DOMString}} |name| names one of these features, then |name|'s <dfn data-dfn-for=
             "powerful feature" class="export">extra permission data</dfn> for an optional
-            <a>environment settings object</a> |settings| is the result of the following algorithm:
+            [=environment settings object=] |settings| is the result of the following algorithm:
           </p>
           <ol class="algorithm">
             <li>If |settings| wasn't passed, set it to the [=current settings object=].
             </li>
             <li>If there was a previous invocation of this algorithm with the same |name| and
-            |settings|, returning |previousResult|, and the user agent has not received <a>new
-            information about the user's intent</a> since that invocation, return |previousResult|.
+            |settings|, returning |previousResult|, and the user agent has not received [=new
+            information about the user's intent=] since that invocation, return |previousResult|.
             </li>
             <li>Return the instance of |name|'s [=powerful feature/extra permission data type=]
             that matches the UA's impression of the user's intent, taking into account any
@@ -585,8 +585,8 @@
             existing instance of the [=powerful feature/permission result type=], and updates the
             [=powerful feature/permission result type=] instance with the query result. Used by
             {{Permissions}}' {{Permissions/query(permissionDesc)}} method and the
-            [=`PermissionStatus` update steps=]. If unspecified, this defaults to the <a>default
-            permission query algorithm</a>.
+            [=`PermissionStatus` update steps=]. If unspecified, this defaults to the [=default
+            permission query algorithm=].
           </p>
           <p>
             The <dfn data-export="">default permission query algorithm</dfn>, given a
@@ -595,7 +595,7 @@
           </p>
           <ol class="algorithm">
             <li>Set <code>|status|</code>'s {{PermissionStatus/state}} to |permissionDesc|'s
-            <a>permission state</a>.
+            [=permission state=].
             </li>
           </ol>
         </dd>
@@ -616,7 +616,7 @@
         <dd>
           <p>
             Takes an [=environment settings object=], and returns a new [=permission key=]. If
-            unspecified, this defaults to the <a>default permission key generation algorithm</a>. A
+            unspecified, this defaults to the [=default permission key generation algorithm=]. A
             feature that specifies a custom [=powerful feature/permission key generation
             algorithm=] MUST also specify a [=powerful feature/permission key comparison
             algorithm=].
@@ -642,8 +642,8 @@
         <dd>
           <p>
             Takes two [=permission keys=] and returns a [=boolean=] that shows whether the two keys
-            are equal. If unspecified, this defaults to the <a>default permission key comparison
-            algorithm</a>.
+            are equal. If unspecified, this defaults to the [=default permission key comparison
+            algorithm=].
           </p>
           <p>
             The <dfn class="export">default permission key comparison algorithm</dfn>, given
@@ -661,7 +661,7 @@
         <dd>
           <p>
             Takes no arguments. Updates any other parts of the implementation that need to be kept
-            in sync with changes in the results of <a>permission states</a> or [=powerful
+            in sync with changes in the results of [=permission states=] or [=powerful
             feature/extra permission data=].
           </p>
           <p>
@@ -733,7 +733,7 @@
         </dd>
       </dl>
       <p>
-        A <dfn class="export">default powerful feature</dfn> is a <a>powerful feature</a> with all
+        A <dfn class="export">default powerful feature</dfn> is a [=powerful feature=] with all
         of the above types and algorithms defaulted.
       </p>
     </section>
@@ -760,7 +760,7 @@
         </ol>
         <p>
           A |descriptor|'s <dfn class="export">permission state</dfn>, given an optional
-          <a>environment settings object</a> |settings| is the result of the following algorithm.
+          [=environment settings object=] |settings| is the result of the following algorithm.
           It returns a {{PermissionState}} enum value:
         </p>
         <ol class="algorithm">
@@ -776,7 +776,7 @@
               <li>Let <var>document</var> be |settings|' [=relevant global object=]'s [=associated
               `Document`=].
               </li>
-              <li>If <var>document</var> is not <a>allowed to use</a> |feature|, return
+              <li>If <var>document</var> is not [=allowed to use=] |feature|, return
               {{PermissionState/"denied"}}.
               </li>
             </ol>
@@ -796,8 +796,8 @@
           </li>
         </ol>
         <p>
-          As a shorthand, a {{DOMString}} |name|'s <a>permission state</a> is the <a>permission
-          state</a> of a {{PermissionDescriptor}} with its {{PermissionDescriptor/name}} member set
+          As a shorthand, a {{DOMString}} |name|'s [=permission state=] is the [=permission
+          state=] of a {{PermissionDescriptor}} with its {{PermissionDescriptor/name}} member set
           to |name|.
         </p>
       </section>
@@ -812,17 +812,17 @@
           {{PermissionState/"granted"}} or {{PermissionState/"denied"}}.
         </p>
         <ol class="algorithm">
-          <li>Let <var>current state</var> be the |descriptor|'s <a>permission state</a>.
+          <li>Let <var>current state</var> be the |descriptor|'s [=permission state=].
           </li>
           <li>If <var>current state</var> is not {{PermissionState/"prompt"}}, return <var>current
           state</var> and abort these steps.
           </li>
-          <li>Ask the user for <a>express permission</a> for the calling algorithm to use the
-          <a>powerful feature</a> described by |descriptor|.
+          <li>Ask the user for [=express permission=] for the calling algorithm to use the
+          [=powerful feature=] described by |descriptor|.
           </li>
           <li>If the user gives [=express permission=] to use the powerful feature, set |current
           state| to {{PermissionState/"granted"}}; otherwise to {{PermissionState/"denied"}}. The
-          user's interaction may provide <a>new information about the user's intent</a> for the
+          user's interaction may provide [=new information about the user's intent=] for the
           [=origin=].
             <p class="note">
               This is intentionally vague about the details of the permission UI and how the user
@@ -841,8 +841,8 @@
           </li>
         </ol>
         <p>
-          As a shorthand, <a>requesting permission to use</a> a {{DOMString}} |name|, is the same
-          as <a>requesting permission to use</a> a {{PermissionDescriptor}} with its
+          As a shorthand, [=requesting permission to use=] a {{DOMString}} |name|, is the same
+          as [=requesting permission to use=] a {{PermissionDescriptor}} with its
           {{PermissionDescriptor/name}} member set to |name|.
         </p>
       </section>
@@ -853,20 +853,20 @@
         <p>
           To <dfn data-lt="prompt the user to choose|prompting the user to choose" class=
           "export">prompt the user to choose</dfn> one or more |options| associated with a given
-          |descriptor:PermissionDescriptor| and an optional <a>boolean</a> |allowMultiple:boolean|
+          |descriptor:PermissionDescriptor| and an optional [=boolean=] |allowMultiple:boolean|
           (default false), the user agent must perform the following steps. This algorithm returns
           either {{PermissionState/"denied"}} or the user's selection.
         </p>
         <ol class="algorithm">
-          <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"denied"}}, return
+          <li>If |descriptor|'s [=permission state=] is {{PermissionState/"denied"}}, return
           {{PermissionState/"denied"}} and abort these steps.
           </li>
-          <li>If |descriptor|'s <a>permission state</a> is {{PermissionState/"granted"}}, the user
+          <li>If |descriptor|'s [=permission state=] is {{PermissionState/"granted"}}, the user
           agent may return one (or more if |allowMultiple| is true) of |options| chosen by the user
           and abort these steps. If the user agent returns without prompting, then subsequent
           <a data-lt="prompt the user to choose">prompts for the user to choose</a> from the same
           set of options with the same |descriptor| must return the same option(s), unless the user
-          agent receives <a>new information about the user's intent</a>.
+          agent receives [=new information about the user's intent=].
           </li>
           <li>Ask the user to choose one or more |options| or deny permission, and wait for them to
           choose:
@@ -889,8 +889,8 @@
           </li>
         </ol>
         <p>
-          As a shorthand, <a>prompting the user to choose</a> from options associated with a
-          {{DOMString}} |name|, is the same as <a>prompting the user to choose</a> from those
+          As a shorthand, [=prompting the user to choose=] from options associated with a
+          {{DOMString}} |name|, is the same as [=prompting the user to choose=] from those
           options associated with a {{PermissionDescriptor}} with its {{PermissionDescriptor/name}}
           member set to |name|.
         </p>
@@ -953,24 +953,24 @@
             `query()` method
           </h4>
           <p>
-            When the <dfn>query()</dfn> method is invoked, the <a>user agent</a> MUST run the
+            When the <dfn>query()</dfn> method is invoked, the [=user agent=] MUST run the
             following <dfn class="export">query a permission</dfn> algorithm, passing the parameter
             <var>permissionDesc</var>:
           </p>
           <ol class="algorithm">
             <li>If [=this=]'s [=relevant global object=] is a {{Window}} object, then:
               <ol>
-                <li>If the [=current settings object=]'s <a>associated `Document`</a> is not
+                <li>If the [=current settings object=]'s [=associated `Document`=] is not
                 [=Document/fully active=], return [=a promise rejected with=] an
                 {{"InvalidStateError"}} {{DOMException}}.
                 </li>
               </ol>
             </li>
-            <li>Let |rootDesc| be the object |permissionDesc| refers to, <a>converted to an IDL
-            value</a> of type {{PermissionDescriptor}}.
+            <li>Let |rootDesc| be the object |permissionDesc| refers to, [=converted to an IDL
+            value=] of type {{PermissionDescriptor}}.
             </li>
-            <li>If the conversion [=exception/throws=] an [=exception=], return <a>a promise
-            rejected with</a> that exception.
+            <li>If the conversion [=exception/throws=] an [=exception=], return [=a promise
+            rejected with=] that exception.
             </li>
             <li>If |rootDesc|["{{PermissionDescriptor/name}}"] is not supported, return [=a promise
             rejected with=] a {{TypeError}}.
@@ -985,18 +985,18 @@
                 </p>
               </aside>
             </li>
-            <li>Let |typedDescriptor| be the object |permissionDesc| refers to, <a>converted to an
-            IDL value</a> of |rootDesc|'s {{PermissionDescriptor/name}}'s [=powerful
+            <li>Let |typedDescriptor| be the object |permissionDesc| refers to, [=converted to an
+            IDL value=] of |rootDesc|'s {{PermissionDescriptor/name}}'s [=powerful
             feature/permission descriptor type=].
             </li>
-            <li>If the conversion [=exception/throws=] an [=exception=], return <a>a promise
-            rejected with</a> that exception.
+            <li>If the conversion [=exception/throws=] an [=exception=], return [=a promise
+            rejected with=] that exception.
             </li>
             <li>Let |promise:Promise| be [=a new promise=].
             </li>
             <li>Return |promise| and continue [=in parallel=]:
               <ol>
-                <li>Let |status| be <a>create a `PermissionStatus`</a> with |typedDescriptor|.
+                <li>Let |status| be [=create a `PermissionStatus`=] with |typedDescriptor|.
                 </li>
                 <li>Let |query| be |status|'s {{PermissionStatus/[[query]]}} internal slot.
                 </li>
@@ -1087,8 +1087,8 @@
             `onchange` attribute
           </h4>
           <p>
-            The <dfn>onchange</dfn> attribute is an <a>event handler</a> whose corresponding
-            <a>event handler event type</a> is <code>change</code>.
+            The <dfn>onchange</dfn> attribute is an [=event handler=] whose corresponding
+            [=event handler event type=] is <code>change</code>.
           </p>
           <p id="PermissionStatus-update">
             Whenever the [=user agent=] is aware that the state of a {{PermissionStatus}} instance
@@ -1112,7 +1112,7 @@
             algorithm=], passing |query| and |status|.
             </li>
             <li>
-              <a>Queue a task</a> on the [=permissions task source=] to <a>fire an event</a> named
+              [=Queue a task=] on the [=permissions task source=] to [=fire an event=] named
               <code>change</code> at |status|.
             </li>
           </ol>
@@ -1183,8 +1183,8 @@
       </h2>
       <p>
         For the purposes of user-agent automation and application testing, this document defines
-        the following <a>extension commands</a> for the [[WebDriver]] specification. It is OPTIONAL
-        for a user agent to support <a>extension commands</a> commands.
+        the following [=extension commands=] for the [[WebDriver]] specification. It is OPTIONAL
+        for a user agent to support [=extension commands=] commands.
       </p>
       <pre class='idl'>
         dictionary PermissionSetParameters {
@@ -1218,49 +1218,49 @@
         </table>
         <p>
           The <dfn class="export" data-dfn-for="extension commands">Set Permission</dfn>
-          <a>extension command</a> simulates user modification of a {{PermissionDescriptor}}'s
-          <a>permission state</a>.
+          [=extension command=] simulates user modification of a {{PermissionDescriptor}}'s
+          [=permission state=].
         </p>
         <p>
-          The <a>remote end steps</a> are:
+          The [=remote end steps=] are:
         </p>
         <ol>
-          <li>Let |parameters| be the |parameters| argument, <a>converted to an IDL value</a> of
+          <li>Let |parameters| be the |parameters| argument, [=converted to an IDL value=] of
           type {{PermissionSetParameters}}. If this throws an exception, return an [=invalid
           argument=] [=error=].
           </li>
           <li>Let |rootDesc| be |parameters|.{{PermissionSetParameters/descriptor}}.
           </li>
-          <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
-          value</a> of <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s [=powerful
+          <li>Let |typedDescriptor| be the object |rootDesc| refers to, [=converted to an IDL
+          value=] of <code>|rootDesc|.{{PermissionDescriptor/name}}</code>'s [=powerful
           feature/permission descriptor type=]. If this throws an exception, return a [=invalid
           argument=] [=error=].
           </li>
-          <li>If |parameters|.{{PermissionSetParameters/state}} is an inappropriate <a>permission
-          state</a> for any implementation-defined reason, return a [=invalid argument=] [=error=].
+          <li>If |parameters|.{{PermissionSetParameters/state}} is an inappropriate [=permission
+          state=] for any implementation-defined reason, return a [=invalid argument=] [=error=].
             <p class="note">
-              For example, <a>user agents</a> that define the "midi" <a>powerful feature</a> as
-              "always on" may choose to reject a command to set the <a>permission state</a> to
+              For example, [=user agents=] that define the "midi" [=powerful feature=] as
+              "always on" may choose to reject a command to set the [=permission state=] to
               {{PermissionState/"denied"}} at this step.
             </p>
           </li>
           <li>Let |settings| be the [=current settings object=].
           </li>
-          <li>Let |targets| be a <a>list</a> containing all <a>environment settings objects</a>
+          <li>Let |targets| be a [=list=] containing all [=environment settings objects=]
           whose [=environment settings object/origin=] is the <a data-lt="same origin">same</a> as
           the [=environment settings object/origin=] of |settings|.
           </li>
-          <li>Let |tasks| be an empty <a>list</a>.
+          <li>Let |tasks| be an empty [=list=].
           </li>
-          <li>For each <a>environment settings object</a> |target| in |targets|:
+          <li>For each [=environment settings object=] |target| in |targets|:
             <ol>
               <li>
-                <a>Queue a task</a> |task| on the [=permissions task source=] of |target|'s
+                [=Queue a task=] |task| on the [=permissions task source=] of |target|'s
                 [=relevant settings object=]'s [=environment settings object/global object=]'s
                 [=Window/browsing context=] to perform the following step:
                 <ol>
                   <li>Interpret |parameters|.{{PermissionSetParameters/state}} as if it were the
-                  result of an invocation of <a>permission state</a> for |typedDescriptor| with the
+                  result of an invocation of [=permission state=] for |typedDescriptor| with the
                   argument |target| made at this moment.
                   </li>
                 </ol>
@@ -1269,15 +1269,15 @@
               </li>
             </ol>
           </li>
-          <li>Wait for all <a>tasks</a> in |tasks| to have executed.
+          <li>Wait for all [=tasks=] in |tasks| to have executed.
           </li>
-          <li>Return <a>success</a> with data `null`.
+          <li>Return [=success=] with data `null`.
           </li>
         </ol>
         <aside class="example" title="Setting a permission via WebDriver">
           <p>
             To [=extension commands/set permission=] for `{name: "midi", sysex: true}` of the
-            [=current settings object=] of the <a>session</a> with ID 23 to "`granted`", the local
+            [=current settings object=] of the [=session=] with ID 23 to "`granted`", the local
             end would POST to `/session/23/permissions` with the body:
           </p>
           <pre class="lang-json">
@@ -1297,7 +1297,7 @@
         Privacy considerations
       </h2>
       <p>
-        An adversary could use a <a>permission state</a> as an element in creating a "fingerprint"
+        An adversary could use a [=permission state=] as an element in creating a "fingerprint"
         corresponding to an end-user. Although an adversary can already determine the state of a
         permission by actually using the API, that often leads to a UI prompt being presented to
         the end-user (if the permission was not already [=permission/granted=]). Even though this


### PR DESCRIPTION
Regex (VSCode):
- from: `<a>(.*?[\s\S\r]*?)</a>`
- to: `[=$1=]`

As per @marcoscaceres's request on https://github.com/w3c/permissions/pull/425.
CC @miketaylr


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/thiagowfx/permissions/pull/428.html" title="Last updated on Nov 22, 2023, 1:37 PM UTC (fed8cf4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/428/f647e6d...thiagowfx:fed8cf4.html" title="Last updated on Nov 22, 2023, 1:37 PM UTC (fed8cf4)">Diff</a>