### PR TITLE
Editorial: Update link to accelerometer permission

### DIFF
--- a/index.html
+++ b/index.html
@@ -1761,7 +1761,7 @@
               <a href="https://webkit.org/">WebKit</a>
             </th>
           </tr>
-          <tr data-cite="accelerometer">
+          <tr data-cite="orientation-event">
             <td class="string-token">
               "[=accelerometer=]"
             </td>
@@ -1772,7 +1772,7 @@
               YES
             </td>
             <td class="spec">
-              [[[accelerometer]]]
+              [[[orientation-event]]]
             </td>
             <td class="imp-chromium">
               YES


### PR DESCRIPTION
It appears that the definition was moved according to https://respec.org/xref/?term=accelerometer&types=_CONCEPT_


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OrKoN/permissions/pull/435.html" title="Last updated on Jan 12, 2024, 3:43 PM UTC (3446e4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/435/8094691...OrKoN:3446e4f.html" title="Last updated on Jan 12, 2024, 3:43 PM UTC (3446e4f)">Diff</a>