### PR TITLE
Require an explicit origin for WebDriver BiDi automation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1324,7 +1324,7 @@
             descriptor type=]. If this throws an exception, return a [=invalid argument=]
             [=error=].
             </li>
-            <li>[=Set a permission=] with |typedDescriptor|,
+            <li>[=Set a permission=] with |typedDescriptor| and
             |parameters|.{{PermissionSetParameters/state}}.
             </li>
             <li>Return <a>success</a> with data `null`.

--- a/index.html
+++ b/index.html
@@ -1240,7 +1240,7 @@
           object/origin=] if |origin| is null, or |origin| otherwise.
           </li>
           <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=] whose
-          [=environment settings object/origin=] is [=same origin=] as |target origin|.
+          [=environment settings object/origin=] is [=same origin=] with |target origin|.
           </li>
           <li>Let |tasks| be an empty <a>list</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -1233,7 +1233,7 @@
         <p>
           To <dfn data-for="WebDriver">set a permission</dfn> given a {{PermissionDescriptor}}
           |descriptor:PermissionDescriptor|, a {{PermissionState}} |state:PermissionState|, and an
-          |origin|:
+          optional |origin|:
         </p>
         <ol>
           <li>Let |target origin| be [=current settings object=]'s [=environment settings
@@ -1325,7 +1325,7 @@
             [=error=].
             </li>
             <li>[=Set a permission=] with |typedDescriptor|,
-            |parameters|.{{PermissionSetParameters/state}} and null.
+            |parameters|.{{PermissionSetParameters/state}}.
             </li>
             <li>Return <a>success</a> with data `null`.
             </li>

--- a/index.html
+++ b/index.html
@@ -1232,14 +1232,15 @@
       <div class="algorithm">
         <p>
           To <dfn data-for="WebDriver">set a permission</dfn> given a {{PermissionDescriptor}}
-          |descriptor:PermissionDescriptor|, and a {{PermissionState}} |state:PermissionState|:
+          |descriptor:PermissionDescriptor|, a {{PermissionState}} |state:PermissionState|, and an
+          |origin|:
         </p>
         <ol>
-          <li>Let |settings| be the [=current settings object=].
+          <li>Let |target origin| be [=current settings object=]'s [=environment settings
+          object/origin=] if |origin| is null, or |origin| otherwise.
           </li>
           <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=] whose
-          [=environment settings object/origin=] is [=same origin=] as the [=environment settings
-          object/origin=] of |settings|.
+          [=environment settings object/origin=] is [=same origin=] as |target origin|.
           </li>
           <li>Let |tasks| be an empty <a>list</a>.
           </li>
@@ -1323,8 +1324,8 @@
             descriptor type=]. If this throws an exception, return a [=invalid argument=]
             [=error=].
             </li>
-            <li>[=Set a permission=] with |typedDescriptor| and
-            |parameters|.{{PermissionSetParameters/state}}.
+            <li>[=Set a permission=] with |typedDescriptor|,
+            |parameters|.{{PermissionSetParameters/state}} and null.
             </li>
             <li>Return <a>success</a> with data `null`.
             </li>
@@ -1431,6 +1432,7 @@
                     permissions.SetPermissionParameters = {
                       descriptor: permissions.PermissionDescriptor,
                       state: permissions.PermissionState,
+                      origin: text,
                     }
                   </pre>
                 </dd>
@@ -1466,7 +1468,9 @@
                   name|'s [=powerful feature/permission descriptor type=]. If this conversion
                   throws an exception, return [=error=] with [=error code=] [=invalid argument=].
                   </li>
-                  <li>[=Set a permission=] with |typedDescriptor| and |state|.
+                  <li>Let |origin| be the value of the `origin` field of |command parameters|.
+                  </li>
+                  <li>[=Set a permission=] with |typedDescriptor|, |state|, and |origin|.
                   </li>
                   <li>Return [=success=] with data `null`.
                   </li>


### PR DESCRIPTION
In WebDriver classic permissions apply to all enviroments that match the origin of the current environment. In WebDriver BiDi using the current view as an input for commands is not encouraged, therefore, this PR extends the WebDriver BiDi command with an explicit origin parameter.

Closes #424

The following tasks have been completed:

 * [ ] Modified Web platform tests: https://github.com/web-platform-tests/wpt/issues/43305

Implementation commitment:

 * [x] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=265621)
 * [x] Blink (link to issue): https://github.com/GoogleChromeLabs/chromium-bidi/issues/1585
 * [ ] Gecko (link to issue): https://github.com/mozilla/standards-positions/issues/930


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OrKoN/permissions/pull/436.html" title="Last updated on Jan 14, 2024, 2:48 PM UTC (2118a06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/436/037a40e...OrKoN:2118a06.html" title="Last updated on Jan 14, 2024, 2:48 PM UTC (2118a06)">Diff</a>