### PR TITLE
Add userContext field to WebDriver BiDi's setPermission

### DIFF
--- a/index.html
+++ b/index.html
@@ -1232,15 +1232,16 @@
       <div class="algorithm">
         <p>
           To <dfn data-for="WebDriver">set a permission</dfn> given a {{PermissionDescriptor}}
-          |descriptor:PermissionDescriptor|, a {{PermissionState}} |state:PermissionState|, and an
-          optional |origin|:
+          |descriptor:PermissionDescriptor|, a {{PermissionState}} |state:PermissionState|, an
+          optional |origin|, and an optional |user agent|:
         </p>
         <ol>
           <li>Let |target origin| be [=current settings object=]'s [=environment settings
           object/origin=] if |origin| is null, or |origin| otherwise.
           </li>
           <li>Let |targets| be a <a>list</a> containing all [=environment settings objects=] whose
-          [=environment settings object/origin=] is [=same origin=] with |target origin|.
+          [=environment settings object/origin=] is [=same origin=] with |target origin|, and which
+          belong to the |user agent| if provided, or all user agents otherwise.
           </li>
           <li>Let |tasks| be an empty <a>list</a>.
           </li>
@@ -1433,6 +1434,7 @@
                       descriptor: permissions.PermissionDescriptor,
                       state: permissions.PermissionState,
                       origin: text,
+                      userContext?: text,
                     }
                   </pre>
                 </dd>
@@ -1459,6 +1461,9 @@
                   </li>
                   <li>Let |state| be the value of the `state` field of |command parameters|.
                   </li>
+                  <li>Let |user context id| be the value of the `userContext` field of |command
+                  parameters|, if present, and `default` otherwise.
+                  </li>
                   <li>If |state| is an inappropriate [=permission state=] for any
                   implementation-defined reason, return [=error=] with [=error code=] [=invalid
                   argument=].
@@ -1470,7 +1475,11 @@
                   </li>
                   <li>Let |origin| be the value of the `origin` field of |command parameters|.
                   </li>
-                  <li>[=Set a permission=] with |typedDescriptor|, |state|, and |origin|.
+                  <li>Let |user agent| be the [=user agent=] that represents the [=user context=]
+                  with the id |user context id|.
+                  </li>
+                  <li>[=Set a permission=] with |typedDescriptor|, |state|, |origin|, and |user
+                  agent|.
                   </li>
                   <li>Return [=success=] with data `null`.
                   </li>


### PR DESCRIPTION
User contexts in WebDriver BiDi represents the same concepts as the user agents in the infra spec: https://w3c.github.io/webdriver-bidi/#user-contexts According to the infra definition a user agent can be a user profile or a private browsing window.

This PR adds an ability for the automation client to configure which "user agent" should the permissions apply too.

closes #439

The following tasks have been completed:

 * [x] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/pull/44327))

Implementation commitment:

 * [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=265621)
 * [x] Blink (link to issue): https://github.com/GoogleChromeLabs/chromium-bidi/issues/1585
 * [ ] Gecko (link to issue): https://github.com/mozilla/standards-positions/issues/930


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OrKoN/permissions/pull/438.html" title="Last updated on Mar 8, 2024, 6:56 AM UTC (cf691dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/438/75ef57e...OrKoN:cf691dd.html" title="Last updated on Mar 8, 2024, 6:56 AM UTC (cf691dd)">Diff</a>