### PR TITLE
Use `object` for PermissionSetParameters.descriptor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1225,7 +1225,7 @@
       </p>
       <pre class='idl'>
         dictionary PermissionSetParameters {
-          required PermissionDescriptor descriptor;
+          required object descriptor;
           required PermissionState state;
         };
       </pre>
@@ -1317,12 +1317,12 @@
                 {{PermissionState/"denied"}} at this step.
               </p>
             </li>
-            <li>Let |rootDesc| be |parameters|.{{PermissionSetParameters/descriptor}}.
+            <li>Let |rootDesc| be |parametersDict|.{{PermissionSetParameters/descriptor}}.
             </li>
-            <li>Let |typedDescriptor| be the object |rootDesc| refers to, <a>converted to an IDL
-            value</a> of |rootDesc|.{{PermissionDescriptor/name}}'s [=powerful feature/permission
-            descriptor type=]. If this throws an exception, return a [=invalid argument=]
-            [=error=].
+            <li>Let |typedDescriptor| be the object |rootDesc| refers to,
+            [=converted to an IDL value=] of [=powerful feature/permission descriptor type=]
+            matching the result of <a data-cite="ecma-262#sec-get-o-p">Get</a>(|rootDesc|,
+            "`name`"). If this throws an exception, return a [=invalid argument=] [=error=].
             </li>
             <li>[=Set a permission=] with |typedDescriptor| and
             |parametersDict|.{{PermissionSetParameters/state}}.


### PR DESCRIPTION
And also fixes rootDesc.name use. Failing to convert `descriptor` would throw at a later step but this shouldn't matter as all error types are same.

closes #443


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/permissions/pull/444.html" title="Last updated on Feb 14, 2024, 10:20 PM UTC (f0a61b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/444/12a5113...saschanaz:f0a61b9.html" title="Last updated on Feb 14, 2024, 10:20 PM UTC (f0a61b9)">Diff</a>