### PR TITLE
Editorial: fix wrong cddl syntax used for optionality of the user context

### DIFF
--- a/index.html
+++ b/index.html
@@ -1437,7 +1437,7 @@
                       descriptor: permissions.PermissionDescriptor,
                       state: permissions.PermissionState,
                       origin: text,
-                      userContext?: text,
+                      ? userContext: text,
                     }
                   </pre>
                 </dd>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OrKoN/permissions/pull/448.html" title="Last updated on Mar 19, 2024, 10:22 AM UTC (03d16d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/448/645867d...OrKoN:03d16d3.html" title="Last updated on Mar 19, 2024, 10:22 AM UTC (03d16d3)">Diff</a>