### PR TITLE
Use `<code>` for references to a CDDL type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1445,9 +1445,9 @@
                   Result Type
                 </dt>
                 <dd>
-                  <pre class="cddl">
+                  <code>
                     EmptyResult
-                  </pre>
+                  </code>
                 </dd>
               </dl>
               <div class="algorithm" data-algorithm=

--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@
           </tr>
           <tr data-cite="orientation-event">
             <td class="string-token">
-              "[=accelerometer=]"
+              [="accelerometer"=]
             </td>
             <td class="is-policy-controlled">
               YES


### PR DESCRIPTION
The spec wrapped the CDDL result type of the Set Permission command in a `<pre class="cddl">` block, even though the return type is actually a reference to a CDDL type defined in WebDriver BiDi.

This update wraps the block into `<code>` instead, following similar conventions used for IDL.

Context for the request is that CDDL definitions defined in specs are now extracted and exposed in Webref to ease validation and integration in tools: https://github.com/w3c/webref/tree/main/ed/cddl


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/permissions/pull/455.html" title="Last updated on Dec 19, 2024, 8:51 PM UTC (d18fc97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/455/4d38a40...tidoust:d18fc97.html" title="Last updated on Dec 19, 2024, 8:51 PM UTC (d18fc97)">Diff</a>