### PR TITLE
Allow for the query algorithm to return `prompt` or `denied` when document is not `allowed to use`

### DIFF
--- a/index.html
+++ b/index.html
@@ -800,7 +800,14 @@
                 [=associated `Document`=].
                 </li>
                 <li>If <var>document</var> is not <a>allowed to use</a> |feature|, return
-                {{PermissionState/"denied"}}.
+                {{PermissionState/"denied"}} or {{PermissionState/"prompt"}}.
+
+                <p class="note">
+                  The {{PermissionState/"prompt"}} may be returned instead of
+                  {{PermissionState/"denied"}} to avoid exposing if the |feature| is
+                  <a>allowed to use</a> to developers. This is done to prevent retaliation against
+                  the user and repeated prompting to the detriment of the user experience.
+              </p>
                 </li>
               </ol>
             </li>


### PR DESCRIPTION


Updated language to allow the query algorithm to return `prompt` or`denied` helps protect the user from exposing their available features and helps prevent retaliation against the user from developers.

closes [#388](https://github.com/w3c/permissions/issues/388)

The following tasks have been completed:

 * [ ] Modified Web platform tests (link)

Implementation commitment:

 * [ ] WebKit (link to issue)
 * [ ] Blink (link to issue)
 * [ ] Gecko (link to issue)

