### PR TITLE
Add an optional `topLevelOrigin` parameter to the `permissions.setPermission` command

### DIFF
--- a/index.html
+++ b/index.html
@@ -1258,7 +1258,7 @@
             <ol>
               <li>Let |settings key| be be the result of [=powerful feature/permission key
               generation algorithm|generating a permission key=] for |descriptor| with |settings|'s
-              [=origin=] and |settings|'s [=environment/top-level origin=].
+              [=environment settings object/origin=] and |settings|'s [=environment/top-level origin=].
               </li>
               <li>Let |matches| be the result of running the [=powerful feature/permission key
               comparison algorithm=] for |descriptor|, given |settings key| and |key|.


### PR DESCRIPTION
Updates the `permissions.setPermission` command and the `permission key generation algorithm`. The command now accepts an optional `topLevelOrigin ` parameter to support permissions that require double-keying, such as the [Storage Access API](https://privacycg.github.io/storage-access/#permissions-integration). The `permission key generation algorithm` has been updated to accept origin and top-level origin as direct inputs, instead of an [Environment Settings Objects](https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object) (ESO). This allows WebDriver to properly set a permission, since it doesn't necessarily have an ESO to pass.

closes #450

The following tasks have been completed:

 * [ ] Modified Web platform tests (link)

Implementation commitment:

 * [ ] WebKit (link to issue)
 * [ ] Blink (link to issue)
 * [ ] Gecko (link to issue)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jalonthomas/permissions/pull/468.html" title="Last updated on Aug 15, 2025, 1:44 PM UTC (4841693)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/468/4f2ccb0...jalonthomas:4841693.html" title="Last updated on Aug 15, 2025, 1:44 PM UTC (4841693)">Diff</a>