### PR TITLE
Add a note about masked returned permission states

### DIFF
--- a/index.html
+++ b/index.html
@@ -1049,6 +1049,15 @@
                 </ol>
               </li>
             </ol>
+            <aside class="note" title="Masking the returned permission state">
+              <p>
+                The <a>user agent</a> MAY, for certain permissions and in specific cases, mask the
+                {{PermissionStatus/state}} of the {{PermissionStatus}} returned by the
+                {{Permissions/query()}} method, by setting it to {{PermissionState/"prompt"}} even
+                if the algorithm above resolves to {{PermissionState/"granted"}} or
+                {{PermissionState/"denied"}}.
+              </p>
+            </aside>
           </div>
         </section>
       </section>


### PR DESCRIPTION
This PR adds a note about the possibility of user agents masking the queried permission states, trying to address https://github.com/w3c/permissions/issues/52. This reflects what WebKit currently does according to https://github.com/mdn/browser-compat-data/issues/25032.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/w3c-permissions/pull/477.html" title="Last updated on Jun 18, 2026, 10:05 AM UTC (c4dcf33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/permissions/477/0051a83...antosart:c4dcf33.html" title="Last updated on Jun 18, 2026, 10:05 AM UTC (c4dcf33)">Diff</a>